### PR TITLE
floating point support (vector map set hmap hset) / issue #21

### DIFF
--- a/src/saux/scommon.h
+++ b/src/saux/scommon.h
@@ -9,7 +9,7 @@ extern "C" {
  *
  * Common stuff
  *
- * Copyright (c) 2015-2019 F. Aragon. All rights reserved.
+ * Copyright (c) 2015-2020 F. Aragon. All rights reserved.
  * Released under the BSD 3-Clause License (see the doc/LICENSE)
  */
 
@@ -425,6 +425,16 @@ S_INLINE uint64_t S_LD_U64(const void *a)
 S_INLINE size_t S_LD_SZT(const void *a)
 {
 	RS_LD_X(a, size_t);
+}
+
+S_INLINE float S_LD_F(const void *a)
+{
+	RS_LD_X(a, float);
+}
+
+S_INLINE double S_LD_D(const void *a)
+{
+	RS_LD_X(a, double);
 }
 
 S_INLINE void S_ST_U16(void *a, uint16_t v)

--- a/src/saux/sdbg.c
+++ b/src/saux/sdbg.c
@@ -3,7 +3,7 @@
  *
  * Debug helpers (data formatting, etc.).
  *
- * Copyright (c) 2015-2019 F. Aragon. All rights reserved.
+ * Copyright (c) 2015-2020 F. Aragon. All rights reserved.
  * Released under the BSD 3-Clause License (see the doc/LICENSE)
  */
 
@@ -23,6 +23,8 @@ const char *sv_type_to_label(const enum eSV_Type t)
 		CXSV(SV_U32);
 		CXSV(SV_I64);
 		CXSV(SV_U64);
+		CXSV(SV_F);
+		CXSV(SV_D);
 		CXSV(SV_GEN);
 	}
 	return "?";

--- a/src/saux/shash.h
+++ b/src/saux/shash.h
@@ -9,7 +9,7 @@ extern "C" {
  *
  * Buffer hashing
  *
- * Copyright (c) 2015-2019 F. Aragon. All rights reserved.
+ * Copyright (c) 2015-2020 F. Aragon. All rights reserved.
  * Released under the BSD 3-Clause License (see the doc/LICENSE)
  *
  * Features:
@@ -53,6 +53,24 @@ S_INLINE uint32_t sh_hash32(uint32_t v)
 S_INLINE uint32_t sh_hash64(uint64_t v)
 {
         return (uint32_t)(v * S_GR64);
+}
+
+// Floating point hashing: if matches the size of integers, use the
+// integer hash. Otherwise, use FNV-1A hashing.
+
+S_INLINE uint32_t sh_hash_f(float v)
+{
+	uint32_t v32;
+	if (sizeof(v) == sizeof(v32)) {
+		memcpy(&v32, &v, sizeof(v));
+		return sh_hash32(v32);
+	}
+	return sh_fnv1a(S_FNV1_INIT, &v, sizeof(v));
+}
+
+S_INLINE uint32_t sh_hash_d(double v)
+{
+	return sh_fnv1a(S_FNV1_INIT, &v, sizeof(v));
 }
 
 #ifdef __cplusplus

--- a/src/shmap.h
+++ b/src/shmap.h
@@ -17,17 +17,27 @@ extern "C" {
  * #DOC Supported key/value modes (enum eSHM_Type):
  * #DOC
  * #DOC
- * #DOC	SHM_II32: 32-bit integer key, 32-bit integer value
+ * #DOC	SHM_II32: int32_t key, int32_t value
  * #DOC
- * #DOC	SHM_UU32: 32-bit unsigned int key, 32-bit unsigned int value
+ * #DOC	SHM_UU32: uint32_t key, uint32_t value
  * #DOC
- * #DOC	SHM_II: 64-bit int key, 64-bit int value
+ * #DOC	SHM_II: int64_t key, int64_t value
  * #DOC
- * #DOC	SHM_IS: 64-bit int key, string value
+ * #DOC	SHM_FF: float (single-precision floating point) key, float value
  * #DOC
- * #DOC	SHM_IP: 64-bit int key, pointer value
+ * #DOC	SHM_DD: double (double-precision floating point) key, double value
  * #DOC
- * #DOC	SHM_SI: 64-bit string key, 64-bit int value
+ * #DOC	SHM_IS: int64_t key, string value
+ * #DOC
+ * #DOC	SHM_IP: int64_t key, pointer value
+ * #DOC
+ * #DOC	SHM_SI: string key, int64_t value
+ * #DOC
+ * #DOC	SHM_DS: double key, string value
+ * #DOC
+ * #DOC	SHM_DP: double key, pointer value
+ * #DOC
+ * #DOC	SHM_SD: string key, double value
  * #DOC
  * #DOC	SHM_SS: string key, string value
  * #DOC
@@ -43,18 +53,28 @@ extern "C" {
  * #DOC
  * #DOC	typedef srt_bool (*srt_hmap_it_ii)(int64_t k, int64_t v, void *context);
  * #DOC
+ * #DOC	typedef srt_bool (*srt_hmap_it_ff)(float k, float v, void *context);
+ * #DOC
+ * #DOC	typedef srt_bool (*srt_hmap_it_dd)(double k, double v, void *context);
+ * #DOC
  * #DOC	typedef srt_bool (*srt_hmap_it_is)(int64_t k, const srt_string *, void *context);
  * #DOC
  * #DOC	typedef srt_bool (*srt_hmap_it_ip)(int64_t k, const void *, void *context);
  * #DOC
  * #DOC	typedef srt_bool (*srt_hmap_it_si)(const srt_string *, int64_t v, void *context);
  * #DOC
+ * #DOC	typedef srt_bool (*srt_hmap_it_ds)(double k, const srt_string *, void *context);
+ * #DOC
+ * #DOC	typedef srt_bool (*srt_hmap_it_dp)(double k, const void *, void *context);
+ * #DOC
+ * #DOC	typedef srt_bool (*srt_hmap_it_sd)(const srt_string *, double v, void *context);
+ * #DOC
  * #DOC	typedef srt_bool (*srt_hmap_it_ss)(const srt_string *, const srt_string *, void *context);
  * #DOC
  * #DOC	typedef srt_bool (*srt_hmap_it_sp)(const srt_string *, const void *, void *context);
  *
- * Copyright (c) 2015-2019 F. Aragon. All rights reserved. Released under
- * the BSD 3-Clause License (see the doc/LICENSE file included).
+ * Copyright (c) 2015-2020 F. Aragon. All rights reserved.
+ * Released under the BSD 3-Clause License (see the doc/LICENSE)
  */
 
 #include "saux/scommon.h"
@@ -76,7 +96,14 @@ enum eSHM_Type0 {
 	SHM0_I32,
 	SHM0_U32,
 	SHM0_I,
-	SHM0_S
+	SHM0_S,
+	SHM0_FF,
+	SHM0_DD,
+	SHM0_DS,
+	SHM0_DP,
+	SHM0_SD,
+	SHM0_F,
+	SHM0_D
 };
 
 enum eSHM_Type {
@@ -87,7 +114,12 @@ enum eSHM_Type {
 	SHM_IP = SHM0_IP,
 	SHM_SI = SHM0_SI,
 	SHM_SS = SHM0_SS,
-	SHM_SP = SHM0_SP
+	SHM_SP = SHM0_SP,
+	SHM_FF = SHM0_FF,
+	SHM_DD = SHM0_DD,
+	SHM_DS = SHM0_DS,
+	SHM_DP = SHM0_DP,
+	SHM_SD = SHM0_SD
 };
 
 struct SHMapI {
@@ -133,6 +165,32 @@ struct SHMapSP {
 	struct SHMapS x;
 	const void *v;
 };
+struct SHMapF {
+	float k;
+};
+struct SHMapD {
+	double k;
+};
+struct SHMapFF {
+	struct SHMapF x;
+	float v;
+};
+struct SHMapDD {
+	struct SHMapD x;
+	double v;
+};
+struct SHMapDS {
+	struct SHMapD x;
+	srt_stringo1 v;
+};
+struct SHMapDP {
+	struct SHMapD x;
+	const void *v;
+};
+struct SHMapSD {
+	struct SHMapS x;
+	double v;
+};
 
 typedef struct S_HMap srt_hmap;
 
@@ -171,7 +229,6 @@ struct S_HMap {
 	struct SDataFull d;
 	uint32_t hbits; /* hash table bits */
 	uint32_t hmask; /* hash table bitmask */
-	uint32_t ksize; /* key size, in bytes */
 	size_t rh_threshold; /* (1 << hbits) * rh_threshold_pct) / 100 */
 	size_t rh_threshold_pct;
 	shm_eq_f eqf;
@@ -184,10 +241,15 @@ struct S_HMap {
  * Configuration
  */
 
+#define SHM_HASH_32(k)	sh_hash32((uint32_t)(k))
+#define SHM_HASH_64(k)	sh_hash64((uint64_t)(k))
+#define SHM_HASH_F(k)	sh_hash_f(k)
+#define SHM_HASH_D(k)	sh_hash_d(k)
+
 #ifdef S_FORCE_USING_MURMUR3
-#define SHM_SHASH ss_mh3_32
+#define SHM_HASH_S ss_mh3_32
 #else
-#define SHM_SHASH ss_fnv1a
+#define SHM_HASH_S ss_fnv1a
 #endif
 
 /*
@@ -221,6 +283,20 @@ S_INLINE uint8_t shm_elem_size(int t)
 		return sizeof(struct SHMapI);
 	case SHM0_S:
 		return sizeof(struct SHMapS);
+	case SHM0_FF:
+		return sizeof(struct SHMapFF);
+	case SHM0_DD:
+		return sizeof(struct SHMapDD);
+	case SHM0_DS:
+		return sizeof(struct SHMapDS);
+	case SHM0_DP:
+		return sizeof(struct SHMapDP);
+	case SHM0_SD:
+		return sizeof(struct SHMapSD);
+	case SHM0_F:
+		return sizeof(struct SHMapF);
+	case SHM0_D:
+		return sizeof(struct SHMapD);
 	default:
 		break;
 	}
@@ -312,7 +388,7 @@ srt_bool shm_empty(const srt_hmap *hm)
 /* #API: |Duplicate hash map|input map|output map|O(n)|1;2| */
 srt_hmap *shm_dup(const srt_hmap *src);
 
-/* #API: |Clear/reset map (keeping map type)|hmap||O(1) for simple maps, O(n) for maps having nodes with strings|1;2| */
+/* #API: |Clear/reset map (keeping map type)|hmap||O(1) for simple maps, O(n) for maps having nodes with strings|0;1| */
 void shm_clear(srt_hmap *hm);
 
 /*
@@ -330,7 +406,7 @@ void shm_free_aux(srt_hmap **s, ...);
  * Copy
  */
 
-/* #API: |Overwrite map with a map copy|output hash map; input map|output map reference (optional usage)|O(n)|1;2| */
+/* #API: |Overwrite map with a map copy|output hash map; input map|output map reference (optional usage)|O(n)|0;1| */
 srt_hmap *shm_cpy(srt_hmap **hm, const srt_hmap *src);
 
 /*
@@ -344,67 +420,107 @@ S_INLINE const void *shm_at_s(const srt_hmap *hm, uint32_t h, const void *key, u
 	return hm ? shm_at(hm, h, key, tl) : NULL;
 }
 
-/* #API: |Access to int32:int32 map|hash map; int32 key|int32|O(n), O(1) average amortized|1;2| */
+/* #API: |Access to element (SHM_II32)|hash map; key|value|O(n), O(1) average amortized|1;2| */
 S_INLINE int32_t shm_at_ii32(const srt_hmap *hm, int32_t k)
 {
 	const struct SHMapii *e = (const struct SHMapii *)
-				shm_at_s(hm, sh_hash32((uint32_t)k), &k, NULL);
+				shm_at_s(hm, SHM_HASH_32(k), &k, NULL);
 	return e ? e->v : 0;
 }
 
-/* #API: |Access to uint32:uint32 map|hash map; uint32 key|uint32|O(n), O(1) average amortized|1;2| */
+/* #API: |Access to element (SHM_UU32)|hash map; key|value|O(n), O(1) average amortized|1;2| */
 S_INLINE uint32_t shm_at_uu32(const srt_hmap *hm, uint32_t k)
 {
 	const struct SHMapuu *e = (const struct SHMapuu *)
-				shm_at_s(hm, sh_hash32((uint32_t)k), &k, NULL);
+				shm_at_s(hm, SHM_HASH_32(k), &k, NULL);
 	return e ? e->v : 0;
 }
 
-/* #API: |Access to int64_t:int64_t map|hash map; integer key|integer|O(n), O(1) average amortized|1;2| */
+/* #API: |Access to element (SHM_II)|hash map; key|value|O(n), O(1) average amortized|1;2| */
 S_INLINE int64_t shm_at_ii(const srt_hmap *hm, int64_t k)
 {
 	const struct SHMapII *e = (const struct SHMapII *)
-				shm_at_s(hm, sh_hash64((uint64_t)k), &k, NULL);
+				shm_at_s(hm, SHM_HASH_64(k), &k, NULL);
 	return e ? e->v : 0;
 }
 
-/* #API: |Access to integer-string map|hash map; integer key|string|O(n), O(1) average amortized|1;2| */
+/* #API: |Access to element (SHM_FF)|hash map; key|value|O(n), O(1) average amortized|1;2| */
+S_INLINE float shm_at_ff(const srt_hmap *hm, float k)
+{
+	const struct SHMapFF *e = (const struct SHMapFF *)
+				shm_at_s(hm, SHM_HASH_F(k), &k, NULL);
+	return e ? e->v : 0;
+}
+
+/* #API: |Access to element (SHM_DD)|hash map; key|value|O(n), O(1) average amortized|1;2| */
+S_INLINE double shm_at_dd(const srt_hmap *hm, double k)
+{
+	const struct SHMapDD *e = (const struct SHMapDD *)
+				shm_at_s(hm, SHM_HASH_D(k), &k, NULL);
+	return e ? e->v : 0;
+}
+
+/* #API: |Access to element (SHM_IS)|hash map; key|value|O(n), O(1) average amortized|0;1| */
 S_INLINE const srt_string *shm_at_is(const srt_hmap *hm, int64_t k)
 {
 	const struct SHMapIS *e = (const struct SHMapIS *)
-				shm_at_s(hm, sh_hash64((uint64_t)k), &k, NULL);
+				shm_at_s(hm, SHM_HASH_64(k), &k, NULL);
 	return e ? sso1_get(&e->v) : 0;
 }
 
-/* #API: |Access to integer-pointer map|hash map; integer key|pointer|O(n), O(1) average amortized|1;2| */
+/* #API: |Access to element (SHM_IP)|hash map; key|value pointer|O(n), O(1) average amortized|0;1| */
 S_INLINE const void *shm_at_ip(const srt_hmap *hm, int64_t k)
 {
 	const struct SHMapIP *e = (const struct SHMapIP *)
-				shm_at_s(hm, sh_hash64((uint64_t)k), &k, NULL);
+				shm_at_s(hm, SHM_HASH_64(k), &k, NULL);
 	return e ? e->v : 0;
 }
 
-/* #API: |Access to string-integer map|hash map; string key|integer|O(n), O(1) average amortized|1;2| */
+/* #API: |Access to element (SHM_SI)|hash map; key|value|O(n), O(1) average amortized|0;1| */
 S_INLINE int64_t shm_at_si(const srt_hmap *hm, const srt_string *k)
 {
 	const struct SHMapSI *e = (const struct SHMapSI *)
-					shm_at_s(hm, SHM_SHASH(k), k, NULL);
+					shm_at_s(hm, SHM_HASH_S(k), k, NULL);
 	return e ? e->v : 0;
 }
 
-/* #API: |Access to string-string map|hash map; string key|string|O(n), O(1) average amortized|1;2| */
+/* #API: |Access to element (SHM_DS)|hash map; key|value|O(n), O(1) average amortized|0;1| */
+S_INLINE const srt_string *shm_at_ds(const srt_hmap *hm, double k)
+{
+	const struct SHMapDS *e = (const struct SHMapDS *)
+				shm_at_s(hm, SHM_HASH_D(k), &k, NULL);
+	return e ? sso1_get(&e->v) : 0;
+}
+
+/* #API: |Access to element (SHM_DP)|hash map; key|value pointer|O(n), O(1) average amortized|0;1| */
+S_INLINE const void *shm_at_dp(const srt_hmap *hm, double k)
+{
+	const struct SHMapDP *e = (const struct SHMapDP *)
+				shm_at_s(hm, SHM_HASH_D(k), &k, NULL);
+	return e ? e->v : 0;
+}
+
+/* #API: |Access to element (SHM_SD)|hash map; key|value|O(n), O(1) average amortized|0;1| */
+S_INLINE double shm_at_sd(const srt_hmap *hm, const srt_string *k)
+{
+	const struct SHMapSD *e = (const struct SHMapSD *)
+					shm_at_s(hm, SHM_HASH_S(k), k, NULL);
+	return e ? e->v : 0;
+}
+
+/* #API: |Access to element (SHM_SS)|hash map; key|value|O(n), O(1) average amortized|1;2| */
 S_INLINE const srt_string *shm_at_ss(const srt_hmap *hm, const srt_string *k)
 {
 	const struct SHMapSS *e = (const struct SHMapSS *)
-					shm_at_s(hm, SHM_SHASH(k), k, NULL);
+					shm_at_s(hm, SHM_HASH_S(k), k, NULL);
 	return e ? sso_get_s2(&e->kv) : ss_void;
 }
 
-/* #API: |Access to string-pointer map|hash map; string key|pointer|O(n), O(1) average amortized|1;2| */
+/* #API: |Access to element (SHM_SP)|hash map; key|value pointer|O(n), O(1) average amortized|1;2| */
 S_INLINE const void *shm_at_sp(const srt_hmap *hm, const srt_string *k)
 {
 	const struct SHMapSP *e = (const struct SHMapSP *)
-					shm_at_s(hm, SHM_SHASH(k), k, NULL);
+					shm_at_s(hm, SHM_HASH_S(k), k, NULL);
 	return e ? e->v : 0;
 }
 
@@ -412,53 +528,84 @@ S_INLINE const void *shm_at_sp(const srt_hmap *hm, const srt_string *k)
  * Existence check
  */
 
-/* #API: |Map element count/check|hash map; 32-bit unsigned integer key|S_TRUE: element found; S_FALSE: not in the map|O(n), O(1) average amortized|1;2| */
-S_INLINE size_t shm_count_u(const srt_hmap *hm, uint32_t k)
+/* #API: |Map element count/check (SHM_UU32)|hash map; key|S_TRUE: element found; S_FALSE: not in the map|O(n), O(1) average amortized|1;2| */
+S_INLINE size_t shm_count_u32(const srt_hmap *hm, uint32_t k)
 {
-	return shm_at_s(hm, sh_hash32(k), &k, NULL) ? 1 : 0;
+	return shm_at_s(hm, SHM_HASH_32(k), &k, NULL) ? 1 : 0;
 }
 
-/* #API: |Map element count/check|hash map; integer key|S_TRUE: element found; S_FALSE: not in the map|O(n), O(1) average amortized|1;2| */
+/* #API: |Map element count/checks (SHM_II32)|hash map; key|S_TRUE: element found; S_FALSE: not in the map|O(n), O(1) average amortized|1;2| */
+S_INLINE size_t shm_count_i32(const srt_hmap *hm, int32_t k)
+{
+	return shm_at_s(hm, SHM_HASH_32(k), &k, NULL) ? 1 : 0;
+}
+
+/* #API: |Map element count/check (SHM_I*)|hash map; key|S_TRUE: element found; S_FALSE: not in the map|O(n), O(1) average amortized|1;2| */
 S_INLINE size_t shm_count_i(const srt_hmap *hm, int64_t k)
 {
-	return hm->ksize == 4 ? shm_count_u(hm, (uint32_t)k) :
-	       hm->ksize == 8 && shm_at_s(hm, sh_hash64((uint64_t)k), &k, NULL)
-								 ? 1 : 0;
+	return shm_at_s(hm, SHM_HASH_64(k), &k, NULL) ? 1 : 0;
 }
 
-/* #API: |Map element count/check|hash map; string key|S_TRUE: element found; S_FALSE: not in the map|O(n), O(1) average amortized|1;2| */
+/* #API: |Map element count/check (SHM_FF)|hash map; key|S_TRUE: element found; S_FALSE: not in the map|O(n), O(1) average amortized|1;2| */
+S_INLINE size_t shm_count_f(const srt_hmap *hm, float k)
+{
+	return shm_at_s(hm, SHM_HASH_F(k), &k, NULL) ? 1 : 0;
+}
+
+/* #API: |Map element count/check (SHM_D*)|hash map; key|S_TRUE: element found; S_FALSE: not in the map|O(n), O(1) average amortized|1;2| */
+S_INLINE size_t shm_count_d(const srt_hmap *hm, double k)
+{
+	return shm_at_s(hm, SHM_HASH_D(k), &k, NULL) ? 1 : 0;
+}
+
+/* #API: |Map element count/check (SHM_S*)|hash map; key|S_TRUE: element found; S_FALSE: not in the map|O(n), O(1) average amortized|1;2| */
 S_INLINE size_t shm_count_s(const srt_hmap *hm, const srt_string *k)
 {
-	return shm_at_s(hm, SHM_SHASH(k), k, NULL) ? 1 : 0;
+	return shm_at_s(hm, SHM_HASH_S(k), k, NULL) ? 1 : 0;
 }
 
 /*
  * Insert
  */
 
-/* #API: |Insert into int32-int32 map|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
+/* #API: |Insert into map (SHM_II32)|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
 srt_bool shm_insert_ii32(srt_hmap **hm, int32_t k, int32_t v);
 
-/* #API: |Insert into uint32-uint32 map|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
+/* #API: |Insert into map (SHM_UU32)|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
 srt_bool shm_insert_uu32(srt_hmap **hm, uint32_t k, uint32_t v);
 
-/* #API: |Insert into int-int map|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
+/* #API: |Insert into map (SHM_II)|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
 srt_bool shm_insert_ii(srt_hmap **hm, int64_t k, int64_t v);
 
-/* #API: |Insert into int-string map|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
+/* #API: |Insert into map (SHM_IS)|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
 srt_bool shm_insert_is(srt_hmap **hm, int64_t k, const srt_string *v);
 
-/* #API: |Insert into int-pointer map|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
+/* #API: |Insert into map (SHM_IP)|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
 srt_bool shm_insert_ip(srt_hmap **hm, int64_t k, const void *v);
 
-/* #API: |Insert into string-int map|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
+/* #API: |Insert into map (SHM_SI)|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
 srt_bool shm_insert_si(srt_hmap **hm, const srt_string *k, int64_t v);
 
-/* #API: |Insert into string-string map|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
+/* #API: |Insert into map (SHM_SS)|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
 srt_bool shm_insert_ss(srt_hmap **hm, const srt_string *k, const srt_string *v);
 
-/* #API: |Insert into string-pointer map|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
+/* #API: |Insert into map (SHM_SP)|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
 srt_bool shm_insert_sp(srt_hmap **hm, const srt_string *k, const void *v);
+
+/* #API: |Insert into map (SHM_FF)|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
+srt_bool shm_insert_ff(srt_hmap **hm, float k, float v);
+
+/* #API: |Insert into map (SHM_DD)|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
+srt_bool shm_insert_dd(srt_hmap **hm, double k, double v);
+
+/* #API: |Insert into map (SHM_DS)|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
+srt_bool shm_insert_ds(srt_hmap **hm, double k, const srt_string *v);
+
+/* #API: |Insert into map (SHM_DP)|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
+srt_bool shm_insert_dp(srt_hmap **hm, double k, const void *v);
+
+/* #API: |Insert into map (SHM_SD)|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
+srt_bool shm_insert_sd(srt_hmap **hm, const srt_string *k, double v);
 
 /* Hash set support (proxy) */
 
@@ -466,31 +613,54 @@ srt_bool shm_insert_i32(srt_hmap **hm, int32_t k);
 srt_bool shm_insert_u32(srt_hmap **hm, uint32_t k);
 srt_bool shm_insert_i(srt_hmap **hm, int64_t k);
 srt_bool shm_insert_s(srt_hmap **hm, const srt_string *k);
+srt_bool shm_insert_f(srt_hmap **hm, float k);
+srt_bool shm_insert_d(srt_hmap **hm, double k);
 
 /*
  * Increment
  */
 
-/* #API: |Increment value into int32-int32 map|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
+/* #API: |Increment value map element (SHM_II32)|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
 srt_bool shm_inc_ii32(srt_hmap **hm, int32_t k, int32_t v);
 
-/* #API: |Increment into uint32-uint32 map|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
+/* #API: |Increment map element (SHM_UU32)|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
 srt_bool shm_inc_uu32(srt_hmap **hm, uint32_t k, uint32_t v);
 
-/* #API: |Increment into int-int map|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
+/* #API: |Increment map element (SHM_II)|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
 srt_bool shm_inc_ii(srt_hmap **hm, int64_t k, int64_t v);
 
-/* #API: |Increment into string-int map|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
+/* #API: |Increment map element (SHM_SI)|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
 srt_bool shm_inc_si(srt_hmap **hm, const srt_string *k, int64_t v);
+
+/* #API: |Increment map element (SHM_FF)|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
+srt_bool shm_inc_ff(srt_hmap **hm, float k, float v);
+
+/* #API: |Increment map element (SHM_DD)|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
+srt_bool shm_inc_dd(srt_hmap **hm, double k, double v);
+
+/* #API: |Increment map element (SHM_SD)|hash map; key; value|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
+srt_bool shm_inc_sd(srt_hmap **hm, const srt_string *k, double v);
 
 /*
  * Delete
  */
 
-/* #API: |Delete map element|hash map; int64_t key|S_TRUE: found and deleted; S_FALSE: not found|O(n), O(1) average amortized|1;2| */
+/* #API: |Delete map element (SHM_II32)|hash map; key|S_TRUE: found and deleted; S_FALSE: not found|O(n), O(1) average amortized|1;2| */
+srt_bool shm_delete_i32(srt_hmap *hm, int32_t k);
+
+/* #API: |Delete map element (SHM_UU32)|hash map; key|S_TRUE: found and deleted; S_FALSE: not found|O(n), O(1) average amortized|1;2| */
+srt_bool shm_delete_u32(srt_hmap *hm, uint32_t k);
+
+/* #API: |Delete map element (SHM_I*)|hash map; key|S_TRUE: found and deleted; S_FALSE: not found|O(n), O(1) average amortized|1;2| */
 srt_bool shm_delete_i(srt_hmap *hm, int64_t k);
 
-/* #API: |Delete map element|hash map; string key|S_TRUE: found and deleted; S_FALSE: not found|O(n), O(1) average amortized|1;2| */
+/* #API: |Delete map element (SHM_FF)|hash map; key|S_TRUE: found and deleted; S_FALSE: not found|O(n), O(1) average amortized|1;2| */
+srt_bool shm_delete_f(srt_hmap *hm, float k);
+
+/* #API: |Delete map element (SHM_D*)|hash map; key|S_TRUE: found and deleted; S_FALSE: not found|O(n), O(1) average amortized|1;2| */
+srt_bool shm_delete_d(srt_hmap *hm, double k);
+
+/* #API: |Delete map element (SHM_S*)|hash map; key|S_TRUE: found and deleted; S_FALSE: not found|O(n), O(1) average amortized|1;2| */
 srt_bool shm_delete_s(srt_hmap *hm, const srt_string *k);
 
 /*
@@ -515,79 +685,122 @@ S_INLINE const uint8_t *shm_enum_r(const srt_hmap *h, size_t i)
 	RETURN_IF(!n, def_v);				\
 	return n_v
 
-/* #API: |Enumerate int32-* map keys|hash map; element, 0 to n - 1|int32_t|O(1)|1;2| */
+/* #API: |Enumerate map keys (SHM_II32)|hash map; element, 0 to n - 1|int32_t|O(1)|1;2| */
 S_INLINE int32_t shm_it_i32_k(const srt_hmap *hm, size_t i)
 {
 	S_SHM_ENUM_AUX_K(struct SHMapi, hm, i, n->k, 0);
 }
 
-/* #API: |Enumerate int32-int32 map values|hash map; element, 0 to n - 1|int32_t|O(1)|1;2| */
+/* #API: |Enumerate map values (SHM_II32)|hash map; element, 0 to n - 1|int32_t|O(1)|1;2| */
 S_INLINE int32_t shm_it_ii32_v(const srt_hmap *hm, size_t i)
 {
 	S_SHM_ENUM_AUX_V(SHM_II32, struct SHMapii, hm, i, n->v, 0);
 }
 
-/* #API: |Enumerate uint32-* map keys|hash map; element, 0 to n - 1|uint32_t|O(1)|1;2| */
+/* #API: |Enumerate map keys (SHM_UU32)|hash map; element, 0 to n - 1|uint32_t|O(1)|1;2| */
 S_INLINE uint32_t shm_it_u32_k(const srt_hmap *hm, size_t i)
 {
 	S_SHM_ENUM_AUX_K(struct SHMapu, hm, i, n->k, 0);
 }
 
-/* #API: |Enumerate uint32-uint32 map values|hash map; element, 0 to n - 1|uint32_t|O(1)|1;2| */
+/* #API: |Enumerate map values (SHM_UU32)|hash map; element, 0 to n - 1|uint32_t|O(1)|1;2| */
 S_INLINE uint32_t shm_it_uu32_v(const srt_hmap *hm, size_t i)
 {
 	S_SHM_ENUM_AUX_V(SHM_UU32, struct SHMapuu, hm, i, n->v, 0);
 }
 
-/* #API: |Enumerate integer-* map keys|hash map; element, 0 to n - 1|int64_t|O(1)|1;2| */
+/* #API: |Enumerate map keys (SHM_I*)|hash map; element, 0 to n - 1|int64_t|O(1)|1;2| */
 S_INLINE int64_t shm_it_i_k(const srt_hmap *hm, size_t i)
 {
 	S_SHM_ENUM_AUX_K(struct SHMapI, hm, i, n->k, 0);
 }
 
-/* #API: |Enumerate integer-interger map values|hash map; element, 0 to n - 1|int64_t|O(1)|1;2| */
+/* #API: |Enumerate map values (SHM_II)|hash map; element, 0 to n - 1|int64_t|O(1)|1;2| */
 S_INLINE int64_t shm_it_ii_v(const srt_hmap *hm, size_t i)
 {
 	S_SHM_ENUM_AUX_V(SHM_II, struct SHMapII, hm, i, n->v, 0);
 }
 
-/* #API: |Enumerate integer-string map values|hash map; element, 0 to n - 1|string|O(1)|1;2| */
+/* #API: |Enumerate map values (SHM_IS)|hash map; element, 0 to n - 1|string|O(1)|1;2| */
 S_INLINE const srt_string *shm_it_is_v(const srt_hmap *hm, size_t i)
 {
 	S_SHM_ENUM_AUX_V(SHM_IS, struct SHMapIS, hm, i,
 			sso_get((const srt_stringo *)&n->v), ss_void);
 }
 
-/* #API: |Enumerate integer-pointer map values|hash map; element, 0 to n - 1|pointer|O(1)|1;2| */
+/* #API: |Enumerate map values (SHM_IP)|hash map; element, 0 to n - 1|pointer|O(1)|1;2| */
 S_INLINE const void *shm_it_ip_v(const srt_hmap *hm, size_t i)
 {
 	S_SHM_ENUM_AUX_V(SHM_IP, struct SHMapIP, hm, i, n->v, NULL);
 }
 
-/* #API: |Enumerate string-* map keys|hash map; element, 0 to n - 1|string|O(1)|1;2| */
+/* #API: |Enumerate map keys (SHM_S*)|hash map; element, 0 to n - 1|string|O(1)|1;2| */
 S_INLINE const srt_string *shm_it_s_k(const srt_hmap *hm, size_t i)
 {
 	S_SHM_ENUM_AUX_K(struct SHMapS, hm, i,
 			 sso_get((const srt_stringo *)&n->k), ss_void);
 }
 
-/* #API: |Enumerate string-integer map values|hash map; element, 0 to n - 1|int64_t|O(1)|1;2| */
+/* #API: |Enumerate map values (SHM_SI)|hash map; element, 0 to n - 1|int64_t|O(1)|1;2| */
 S_INLINE int64_t shm_it_si_v(const srt_hmap *hm, size_t i)
 {
 	S_SHM_ENUM_AUX_V(SHM_SI, struct SHMapSI, hm, i, n->v, 0);
 }
 
-/* #API: |Enumerate string-string map values|hash map; element, 0 to n - 1|string|O(1)|1;2| */
+/* #API: |Enumerate map values (SHM_SS)|hash map; element, 0 to n - 1|string|O(1)|1;2| */
 S_INLINE const srt_string *shm_it_ss_v(const srt_hmap *hm, size_t i)
 {
 	S_SHM_ENUM_AUX_V(SHM_SS, struct SHMapSS, hm, i, sso_get_s2(&n->kv),
 			 ss_void);
 }
 
-/* #API: |Enumerate string-pointer map|hash map; element, 0 to n - 1|pointer|O(1)|1;2| */
+/* #API: |Enumerate map (SHM_SP)|hash map; element, 0 to n - 1|pointer|O(1)|1;2| */
 S_INLINE const void *shm_it_sp_v(const srt_hmap *hm, size_t i)
 {
 	S_SHM_ENUM_AUX_V(SHM_SP, struct SHMapSP, hm, i, n->v, NULL);
+}
+
+/* #API: |Enumerate map keys (SHM_FF)|hash map; element, 0 to n - 1|float|O(1)|1;2| */
+S_INLINE float shm_it_f_k(const srt_hmap *hm, size_t i)
+{
+	S_SHM_ENUM_AUX_K(struct SHMapF, hm, i, n->k, 0);
+}
+
+/* #API: |Enumerate map values (SHM_FF)|hash map; element, 0 to n - 1|float|O(1)|1;2| */
+S_INLINE float shm_it_ff_v(const srt_hmap *hm, size_t i)
+{
+	S_SHM_ENUM_AUX_V(SHM_FF, struct SHMapFF, hm, i, n->v, 0);
+}
+
+/* #API: |Enumerate map keys (SHM_D*)|hash map; element, 0 to n - 1|double|O(1)|1;2| */
+S_INLINE double shm_it_d_k(const srt_hmap *hm, size_t i)
+{
+	S_SHM_ENUM_AUX_K(struct SHMapD, hm, i, n->k, 0);
+}
+
+/* #API: |Enumerate map values (SHM_DD)|hash map; element, 0 to n - 1|double|O(1)|1;2| */
+S_INLINE double shm_it_dd_v(const srt_hmap *hm, size_t i)
+{
+	S_SHM_ENUM_AUX_V(SHM_DD, struct SHMapDD, hm, i, n->v, 0);
+}
+
+/* #API: |Enumerate map values (SHM_DS)|hash map; element, 0 to n - 1|double|O(1)|1;2| */
+S_INLINE const srt_string *shm_it_ds_v(const srt_hmap *hm, size_t i)
+{
+	S_SHM_ENUM_AUX_V(SHM_DS, struct SHMapDS, hm, i,
+			sso_get((const srt_stringo *)&n->v), ss_void);
+}
+
+/* #API: |Enumerate map values (SHM_DP)|hash map; element, 0 to n - 1|double|O(1)|1;2| */
+S_INLINE const void *shm_it_dp_v(const srt_hmap *hm, size_t i)
+{
+	S_SHM_ENUM_AUX_V(SHM_DP, struct SHMapDP, hm, i, n->v, 0);
+}
+
+/* #API: |Enumerate map values (SHM_SD)|hash map; element, 0 to n - 1|int64_t|O(1)|1;2| */
+S_INLINE double shm_it_sd_v(const srt_hmap *hm, size_t i)
+{
+	S_SHM_ENUM_AUX_V(SHM_SD, struct SHMapSD, hm, i, n->v, 0);
 }
 
 /*
@@ -597,34 +810,54 @@ S_INLINE const void *shm_it_sp_v(const srt_hmap *hm, size_t i)
 typedef srt_bool (*srt_hmap_it_ii32)(int32_t k, int32_t v, void *context);
 typedef srt_bool (*srt_hmap_it_uu32)(uint32_t k, uint32_t v, void *context);
 typedef srt_bool (*srt_hmap_it_ii)(int64_t k, int64_t v, void *context);
+typedef srt_bool (*srt_hmap_it_ff)(float k, float v, void *context);
+typedef srt_bool (*srt_hmap_it_dd)(double k, double v, void *context);
 typedef srt_bool (*srt_hmap_it_is)(int64_t k, const srt_string *, void *context);
 typedef srt_bool (*srt_hmap_it_ip)(int64_t k, const void *, void *context);
 typedef srt_bool (*srt_hmap_it_si)(const srt_string *, int64_t v, void *context);
+typedef srt_bool (*srt_hmap_it_ds)(double k, const srt_string *, void *context);
+typedef srt_bool (*srt_hmap_it_dp)(double k, const void *, void *context);
+typedef srt_bool (*srt_hmap_it_sd)(const srt_string *, double v, void *context);
 typedef srt_bool (*srt_hmap_it_ss)(const srt_string *, const srt_string *, void *context);
 typedef srt_bool (*srt_hmap_it_sp)(const srt_string *, const void *, void *context);
 
-/* #API: |Enumerate map elements in portions|map; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
+/* #API: |Enumerate map elements in portions (SHM_II32)|map; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
 size_t shm_itp_ii32(const srt_hmap *m, size_t begin, size_t end, srt_hmap_it_ii32 f, void *context);
 
-/* #API: |Enumerate map elements in portions|map; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
+/* #API: |Enumerate map elements in portions (SHM_UU32)|map; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
 size_t shm_itp_uu32(const srt_hmap *m, size_t begin, size_t end, srt_hmap_it_uu32 f, void *context);
 
-/* #API: |Enumerate map elements in portions|map; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
+/* #API: |Enumerate map elements in portions (SHM_II)|map; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
 size_t shm_itp_ii(const srt_hmap *m, size_t begin, size_t end, srt_hmap_it_ii f, void *context);
 
-/* #API: |Enumerate map elements in portions|map; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
+/* #API: |Enumerate map elements in portions (SHM_FF)|map; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
+size_t shm_itp_ff(const srt_hmap *m, size_t begin, size_t end, srt_hmap_it_ff f, void *context);
+
+/* #API: |Enumerate map elements in portions (SHM_DD)|map; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
+size_t shm_itp_dd(const srt_hmap *m, size_t begin, size_t end, srt_hmap_it_dd f, void *context);
+
+/* #API: |Enumerate map elements in portions (SHM_IS)|map; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
 size_t shm_itp_is(const srt_hmap *m, size_t begin, size_t end, srt_hmap_it_is f, void *context);
 
-/* #API: |Enumerate map elements in portions|map; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
+/* #API: |Enumerate map elements in portions (SHM_IP)|map; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
 size_t shm_itp_ip(const srt_hmap *m, size_t begin, size_t end, srt_hmap_it_ip f, void *context);
 
-/* #API: |Enumerate map elements in portions|map; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
+/* #API: |Enumerate map elements in portions (SHM_SI)|map; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
 size_t shm_itp_si(const srt_hmap *m, size_t begin, size_t end, srt_hmap_it_si f, void *context);
 
-/* #API: |Enumerate map elements in portions|map; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
+/* #API: |Enumerate map elements in portions (SHM_DS)|map; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
+size_t shm_itp_ds(const srt_hmap *m, size_t begin, size_t end, srt_hmap_it_ds f, void *context);
+
+/* #API: |Enumerate map elements in portions (SHM_DP)|map; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
+size_t shm_itp_dp(const srt_hmap *m, size_t begin, size_t end, srt_hmap_it_dp f, void *context);
+
+/* #API: |Enumerate map elements in portions (SHM_SD)|map; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
+size_t shm_itp_sd(const srt_hmap *m, size_t begin, size_t end, srt_hmap_it_sd f, void *context);
+
+/* #API: |Enumerate map elements in portions (SHM_SS)|map; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
 size_t shm_itp_ss(const srt_hmap *m, size_t begin, size_t end, srt_hmap_it_ss f, void *context);
 
-/* #API: |Enumerate map elements in portions|map; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
+/* #API: |Enumerate map elements in portions (SHM_SP)|map; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
 size_t shm_itp_sp(const srt_hmap *m, size_t begin, size_t end, srt_hmap_it_sp f, void *context);
 
 #ifdef __cplusplus

--- a/src/shset.c
+++ b/src/shset.c
@@ -3,66 +3,44 @@
  *
  * Hash set handling
  *
- * Copyright (c) 2015-2019 F. Aragon. All rights reserved. Released under
- * the BSD 3-Clause License (see the doc/LICENSE file included).
+ * Copyright (c) 2015-2020 F. Aragon. All rights reserved.
+ * Released under the BSD 3-Clause License (see the doc/LICENSE)
  */
 
 #include "shset.h"
 
-#define SHS_ITP_X(t, hs, f, begin, end)                                        \
-	size_t cnt = 0, ms;                                                    \
-	const uint8_t *d0, *db, *de;                                           \
-	RETURN_IF(!hs || t != hs->d.sub_type, 0);                              \
-	ms = shs_size(hs);                                                     \
-	RETURN_IF(begin > ms || begin >= end, 0);                              \
-	if (end > ms)                                                          \
-		end = ms;                                                      \
-	RETURN_IF(!f, end - begin);                                            \
-	d0 = shm_get_buffer_r(hs);                                             \
-	db = d0 + hs->d.elem_size * begin;                                     \
-	de = d0 + hs->d.elem_size * end;                                       \
-	for (; db < de; db += hs->d.elem_size, cnt++)
-
-size_t shs_itp_i32(const srt_hset *hs, size_t begin, size_t end,
-		   srt_hset_it_i32 f, void *context)
-{
-	SHS_ITP_X(SHS_I32, hs, f, begin, end)
-	{
-		if (!f(((const struct SHMapi *)db)->k, context))
-			break;
+#define SHS_ITP_CNUM(TS) f(((const TS *)db)->k, context)
+#define SHS_ITP_CS f(sso1_get(&((const struct SHMapS *)db)->k), context)
+#define BUILD_SHS_ITP(FN, CBFT, ID, TS, COND)                                  \
+	size_t FN(const srt_hset *hs, size_t begin, size_t end, CBFT f,        \
+		  void *context)                                               \
+	{                                                                      \
+		size_t cnt = 0, ms;                                            \
+		const uint8_t *d0, *db, *de;                                   \
+		RETURN_IF(!hs || ID != hs->d.sub_type, 0);                     \
+		ms = shs_size(hs);                                             \
+		RETURN_IF(begin > ms || begin >= end, 0);                      \
+		if (end > ms)                                                  \
+			end = ms;                                              \
+		RETURN_IF(!f, end - begin);                                    \
+		d0 = shm_get_buffer_r(hs);                                     \
+		db = d0 + hs->d.elem_size * begin;                             \
+		de = d0 + hs->d.elem_size * end;                               \
+		for (; db < de; db += hs->d.elem_size, cnt++) {                \
+			if (!COND)                                             \
+				break;                                         \
+		}                                                              \
+		return cnt;                                                    \
 	}
-	return cnt;
-}
 
-size_t shs_itp_u32(const srt_hset *hs, size_t begin, size_t end,
-		   srt_hset_it_u32 f, void *context)
-{
-	SHS_ITP_X(SHS_U32, hs, f, begin, end)
-	{
-		if (!f(((const struct SHMapu *)db)->k, context))
-			break;
-	}
-	return cnt;
-}
-
-size_t shs_itp_i(const srt_hset *hs, size_t begin, size_t end, srt_hset_it_i f,
-		 void *context)
-{
-	SHS_ITP_X(SHS_I, hs, f, begin, end)
-	{
-		if (!f(((const struct SHMapI *)db)->k, context))
-			break;
-	}
-	return cnt;
-}
-
-size_t shs_itp_s(const srt_hset *hs, size_t begin, size_t end, srt_hset_it_s f,
-		 void *context)
-{
-	SHS_ITP_X(SHS_S, hs, f, begin, end)
-	{
-		if (!f(sso1_get(&((const struct SHMapS *)db)->k), context))
-			break;
-	}
-	return cnt;
-}
+BUILD_SHS_ITP(shs_itp_i32, srt_hset_it_i32, SHS_I32, struct SHMapi,
+	      SHS_ITP_CNUM(struct SHMapi))
+BUILD_SHS_ITP(shs_itp_u32, srt_hset_it_u32, SHS_U32, struct SHMapu,
+	      SHS_ITP_CNUM(struct SHMapu))
+BUILD_SHS_ITP(shs_itp_i, srt_hset_it_i, SHS_I, struct SHMapI,
+	      SHS_ITP_CNUM(struct SHMapI))
+BUILD_SHS_ITP(shs_itp_f, srt_hset_it_f, SHS_F, struct SHMapF,
+	      SHS_ITP_CNUM(struct SHMapF))
+BUILD_SHS_ITP(shs_itp_d, srt_hset_it_d, SHS_D, struct SHMapD,
+	      SHS_ITP_CNUM(struct SHMapD))
+BUILD_SHS_ITP(shs_itp_s, srt_hset_it_s, SHS_S, struct SHMapS, SHS_ITP_CS)

--- a/src/shset.h
+++ b/src/shset.h
@@ -17,11 +17,15 @@ extern "C" {
  * #DOC Supported set modes (enum eSHS_Type):
  * #DOC
  * #DOC
- * #DOC 	SHS_I32: 32-bit integer key
+ * #DOC 	SHS_I32: int32_t key
  * #DOC
- * #DOC 	SHS_U32: 32-bit unsigned int key
+ * #DOC 	SHS_U32: uint32_t key
  * #DOC
- * #DOC 	SHS_I: 64-bit int key
+ * #DOC 	SHS_I: int64_t key
+ * #DOC
+ * #DOC 	SHS_F: float (single-precision floating point) key
+ * #DOC
+ * #DOC 	SHS_D: double (double-precision floating point) key
  * #DOC
  * #DOC 	SHS_S: string key
  * #DOC
@@ -35,10 +39,14 @@ extern "C" {
  * #DOC
  * #DOC	typedef srt_bool (*srt_hset_it_i)(int64_t k, void *context);
  * #DOC
+ * #DOC	typedef srt_bool (*srt_hset_it_f)(float k, void *context);
+ * #DOC
+ * #DOC	typedef srt_bool (*srt_hset_it_d)(double k, void *context);
+ * #DOC
  * #DOC	typedef srt_bool (*srt_hset_it_s)(const srt_string *, void *context);
  *
- * Copyright (c) 2015-2019 F. Aragon. All rights reserved. Released under
- * the BSD 3-Clause License (see the doc/LICENSE file included).
+ * Copyright (c) 2015-2020 F. Aragon. All rights reserved.
+ * Released under the BSD 3-Clause License (see the doc/LICENSE)
  */
 
 #include "shmap.h"
@@ -51,6 +59,8 @@ enum eSHS_Type {
 	SHS_I32 = SHM0_I32,
 	SHS_U32 = SHM0_U32,
 	SHS_I = SHM0_I,
+	SHS_F = SHM0_F,
+	SHS_D = SHM0_D,
 	SHS_S = SHM0_S
 };
 
@@ -156,19 +166,37 @@ S_INLINE srt_hset *shs_cpy(srt_hset **hs, const srt_hset *src)
  * Existence check
  */
 
-/* #API: |Map element count/check|hash set; 32-bit unsigned integer key|S_TRUE: element found; S_FALSE: not in the hash setO(n), O(1) average amortized|1;2| */
-S_INLINE size_t shs_count_u(const srt_hset *hs, uint32_t k)
+/* #API: |Map element count/check (SHS_U32)|hash set; key|S_TRUE: element found; S_FALSE: not in the hash set | O(n), O(1) average amortized|1;2| */
+S_INLINE size_t shs_count_u32(const srt_hset *hs, uint32_t k)
 {
-	return shm_count_u(hs, k);
+	return shm_count_u32(hs, k);
 }
 
-/* #API: |Map element count/check|hash set; integer key|S_TRUE: element found; S_FALSE: not in the hash setO(n), O(1) average amortized|1;2| */
+/* #API: |Map element count/check (SHS_I32)|hash set; key|S_TRUE: element found; S_FALSE: not in the hash set | O(n), O(1) average amortized|1;2| */
+S_INLINE size_t shs_count_i32(const srt_hset *hs, int32_t k)
+{
+	return shm_count_i32(hs, k);
+}
+
+/* #API: |Map element count/check (SHS_I)|hash set; key|S_TRUE: element found; S_FALSE: not in the hash set | O(n), O(1) average amortized|1;2| */
 S_INLINE size_t shs_count_i(const srt_hset *hs, int64_t k)
 {
 	return shm_count_i(hs, k);
 }
 
-/* #API: |Map element count/check|hash set; string key|S_TRUE: element found; S_FALSE: not in the hash setO(n), O(1) average amortized|1;2| */
+/* #API: |Map element count/check (SHS_F)|hash set; key|S_TRUE: element found; S_FALSE: not in the hash set | O(n), O(1) average amortized|1;2| */
+S_INLINE size_t shs_count_f(const srt_hset *hs, float k)
+{
+	return shm_count_f(hs, k);
+}
+
+/* #API: |Map element count/check (SHS_D)|hash set; key|S_TRUE: element found; S_FALSE: not in the hash set | O(n), O(1) average amortized|1;2| */
+S_INLINE size_t shs_count_d(const srt_hset *hs, double k)
+{
+	return shm_count_d(hs, k);
+}
+
+/* #API: |Map element count/check (SHS_S)|hash set; key|S_TRUE: element found; S_FALSE: not in the hash set | O(n), O(1) average amortized|1;2| */
 S_INLINE size_t shs_count_s(const srt_hset *hs, const srt_string *k)
 {
 	return shm_count_s(hs, k);
@@ -178,25 +206,37 @@ S_INLINE size_t shs_count_s(const srt_hset *hs, const srt_string *k)
  * Insert
  */
 
-/* #API: |Insert into int32-int32 hash set|hash set; key|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
+/* #API: |Insert into hash set (SHS_I32)|hash set; key|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
 S_INLINE srt_bool shs_insert_i32(srt_hset **hs, int32_t k)
 {
 	return shm_insert_i32(hs, k);
 }
 
-/* #API: |Insert into uint32-uint32 hash set|hash set; key|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
+/* #API: |Insert into hash set (SHS_U32)|hash set; key|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
 S_INLINE srt_bool shs_insert_u32(srt_hset **hs, uint32_t k)
 {
 	return shm_insert_u32(hs, k);
 }
 
-/* #API: |Insert into int-int hash set|hash set; key|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
+/* #API: |Insert into hash set (SHS_I)|hash set; key|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
 S_INLINE srt_bool shs_insert_i(srt_hset **hs, int64_t k)
 {
 	return shm_insert_i(hs, k);
 }
 
-/* #API: |Insert into string-int hash set|hash set; key|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
+/* #API: |Insert into hash set (SHS_F)|hash set; key|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
+S_INLINE srt_bool shs_insert_f(srt_hset **hs, float k)
+{
+	return shm_insert_f(hs, k);
+}
+
+/* #API: |Insert into hash set (SHS_D)|hash set; key|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
+S_INLINE srt_bool shs_insert_d(srt_hset **hs, double k)
+{
+	return shm_insert_d(hs, k);
+}
+
+/* #API: |Insert into hash set (SHS_S)|hash set; key|S_TRUE: OK, S_FALSE: insertion error|O(n), O(1) average amortized|1;2| */
 S_INLINE srt_bool shs_insert_s(srt_hset **hs, const srt_string *k)
 {
 	return shm_insert_s(hs, k);
@@ -206,13 +246,37 @@ S_INLINE srt_bool shs_insert_s(srt_hset **hs, const srt_string *k)
  * Delete
  */
 
-/* #API: |Delete map element|hash set; int64_t key|S_TRUE: found and deleted; S_FALSE: not found|O(n), O(1) average amortized|1;2| */
+/* #API: |Delete map element (SHS_U32)|hash set; int32_t key|S_TRUE: found and deleted; S_FALSE: not found|O(n), O(1) average amortized|1;2| */
+S_INLINE srt_bool shs_delete_u32(srt_hset *hs, uint32_t k)
+{
+	return shm_delete_u32(hs, k);
+}
+
+/* #API: |Delete map element (SHS_I32)|hash set; int32_t key|S_TRUE: found and deleted; S_FALSE: not found|O(n), O(1) average amortized|1;2| */
+S_INLINE srt_bool shs_delete_i32(srt_hset *hs, int32_t k)
+{
+	return shm_delete_i32(hs, k);
+}
+
+/* #API: |Delete map element (SHS_I)|hash set; int64_t key|S_TRUE: found and deleted; S_FALSE: not found|O(n), O(1) average amortized|1;2| */
 S_INLINE srt_bool shs_delete_i(srt_hset *hs, int64_t k)
 {
 	return shm_delete_i(hs, k);
 }
 
-/* #API: |Delete map element|hash set; string key|S_TRUE: found and deleted; S_FALSE: not found|O(n), O(1) average amortized|1;2| */
+/* #API: |Delete map element (SHS_F)|hash set; float key|S_TRUE: found and deleted; S_FALSE: not found|O(n), O(1) average amortized|1;2| */
+S_INLINE srt_bool shs_delete_f(srt_hset *hs, float k)
+{
+	return shm_delete_f(hs, k);
+}
+
+/* #API: |Delete map element (SHS_D)|hash set; double key|S_TRUE: found and deleted; S_FALSE: not found|O(n), O(1) average amortized|1;2| */
+S_INLINE srt_bool shs_delete_d(srt_hset *hs, double k)
+{
+	return shm_delete_d(hs, k);
+}
+
+/* #API: |Delete map element (SHS_S)|hash set; string key|S_TRUE: found and deleted; S_FALSE: not found|O(n), O(1) average amortized|1;2| */
 S_INLINE srt_bool shs_delete_s(srt_hset *hs, const srt_string *k)
 {
 	return shm_delete_s(hs, k);
@@ -222,25 +286,37 @@ S_INLINE srt_bool shs_delete_s(srt_hset *hs, const srt_string *k)
  * Enumeration
  */
 
-/* #API: |Enumerate int32-* map keys|hash set; element, 0 to n - 1|int32_t|O(1)|1;2| */
+/* #API: |Enumerate set keys (SHS_I32)|hash set; element, 0 to n - 1|int32_t|O(1)|1;2| */
 S_INLINE int32_t shs_it_i32(const srt_hset *hs, size_t i)
 {
 	return shm_it_i32_k(hs, i);
 }
 
-/* #API: |Enumerate uint32-* map keys|hash set; element, 0 to n - 1|uint32_t|O(1)|1;2| */
+/* #API: |Enumerate set keys (SHS_U32)|hash set; element, 0 to n - 1|uint32_t|O(1)|1;2| */
 S_INLINE uint32_t shs_it_u32(const srt_hset *hs, size_t i)
 {
 	return shm_it_u32_k(hs, i);
 }
 
-/* #API: |Enumerate integer-* map keys|hash set; element, 0 to n - 1|int64_t|O(1)|1;2| */
+/* #API: |Enumerate set keys (SHS_I)|hash set; element, 0 to n - 1|int64_t|O(1)|1;2| */
 S_INLINE int64_t shs_it_i(const srt_hset *hs, size_t i)
 {
 	return shm_it_i_k(hs, i);
 }
 
-/* #API: |Enumerate string-* map keys|hash set; element, 0 to n - 1|string|O(1)|1;2| */
+/* #API: |Enumerate set keys (SHS_F)|hash set; element, 0 to n - 1|int64_t|O(1)|0;1| */
+S_INLINE float shs_it_f(const srt_hset *hs, size_t i)
+{
+	return shm_it_f_k(hs, i);
+}
+
+/* #API: |Enumerate set keys (SHS_D)|hash set; element, 0 to n - 1|int64_t|O(1)|0;1| */
+S_INLINE double shs_it_d(const srt_hset *hs, size_t i)
+{
+	return shm_it_d_k(hs, i);
+}
+
+/* #API: |Enumerate set keys (SHS_S)|hash set; element, 0 to n - 1|string|O(1)|1;2| */
 S_INLINE const srt_string *shs_it_s(const srt_hset *hs, size_t i)
 {
 	return shm_it_s_k(hs, i);
@@ -253,18 +329,26 @@ S_INLINE const srt_string *shs_it_s(const srt_hset *hs, size_t i)
 typedef srt_bool (*srt_hset_it_i32)(int32_t k, void *context);
 typedef srt_bool (*srt_hset_it_u32)(uint32_t k, void *context);
 typedef srt_bool (*srt_hset_it_i)(int64_t k, void *context);
+typedef srt_bool (*srt_hset_it_f)(float k, void *context);
+typedef srt_bool (*srt_hset_it_d)(double k, void *context);
 typedef srt_bool (*srt_hset_it_s)(const srt_string *, void *context);
 
-/* #API: |Enumerate set elements in portions|set; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
+/* #API: |Enumerate set elements in portions (SHS_I32)|set; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
 size_t shs_itp_i32(const srt_hset *s, size_t begin, size_t end, srt_hset_it_i32 f, void *context);
 
-/* #API: |Enumerate set elements in portions|set; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
+/* #API: |Enumerate set elements in portions (SHS_U32)|set; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
 size_t shs_itp_u32(const srt_hset *s, size_t begin, size_t end, srt_hset_it_u32 f, void *context);
 
-/* #API: |Enumerate set elements in portions|set; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
+/* #API: |Enumerate set elements in portions (SHS_I)|set; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
 size_t shs_itp_i(const srt_hset *s, size_t begin, size_t end, srt_hset_it_i f, void *context);
 
-/* #API: |Enumerate set elements in portions|set; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
+/* #API: |Enumerate set elements in portions (SHS_F)|set; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
+size_t shs_itp_f(const srt_hset *s, size_t begin, size_t end, srt_hset_it_f f, void *context);
+
+/* #API: |Enumerate set elements in portions (SHS_D)|set; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
+size_t shs_itp_d(const srt_hset *s, size_t begin, size_t end, srt_hset_it_d f, void *context);
+
+/* #API: |Enumerate set elements in portions (SHS_S)|set; index start; index end; callback function; callback function context|Elements processed|O(n)|1;2| */
 size_t shs_itp_s(const srt_hset *s, size_t begin, size_t end, srt_hset_it_s f, void *context);
 
 #ifdef __cplusplus

--- a/src/smset.c
+++ b/src/smset.c
@@ -3,7 +3,7 @@
  *
  * Set handling.
  *
- * Copyright (c) 2015-2019 F. Aragon. All rights reserved.
+ * Copyright (c) 2015-2020 F. Aragon. All rights reserved.
  * Released under the BSD 3-Clause License (see the doc/LICENSE)
  */
 
@@ -31,3 +31,13 @@ SM_ENUM_INORDER_XX(
 	cmp_ns_s((const struct SMapS *)cn, kmax),
 	f(sso_get((const srt_stringo *)&((const struct SMapS *)cn)->k),
 	  context))
+
+SM_ENUM_INORDER_XX(sms_itr_f, srt_set_it_f, SM0_F, float,
+		   cmp_nF_F((const struct SMapF *)cn, kmin),
+		   cmp_nF_F((const struct SMapF *)cn, kmax),
+		   f(((const struct SMapF *)cn)->k, context))
+
+SM_ENUM_INORDER_XX(sms_itr_d, srt_set_it_d, SM0_D, double,
+		   cmp_nD_D((const struct SMapD *)cn, kmin),
+		   cmp_nD_D((const struct SMapD *)cn, kmax),
+		   f(((const struct SMapD *)cn)->k, context))

--- a/src/smset.h
+++ b/src/smset.h
@@ -16,11 +16,15 @@ extern "C" {
  * #DOC Supported set modes (enum eSMS_Type):
  * #DOC
  * #DOC
- * #DOC 	SMS_I32: 32-bit integer key
+ * #DOC 	SMS_I32: int32_t key
  * #DOC
- * #DOC 	SMS_U32: 32-bit unsigned int key
+ * #DOC 	SMS_U32: uint32_t key
  * #DOC
- * #DOC 	SMS_I: 64-bit int key
+ * #DOC 	SMS_I: int64_t key
+ * #DOC
+ * #DOC 	SMS_F: float (single-precision floating point) key
+ * #DOC
+ * #DOC 	SMS_D: double (double-precision floating point) key
  * #DOC
  * #DOC 	SMS_S: string key
  * #DOC
@@ -34,9 +38,13 @@ extern "C" {
  * #DOC
  * #DOC	typedef srt_bool (*srt_set_it_i)(int64_t k, void *context);
  * #DOC
+ * #DOC	typedef srt_bool (*srt_set_it_f)(float k, void *context);
+ * #DOC
+ * #DOC	typedef srt_bool (*srt_set_it_d)(double k, void *context);
+ * #DOC
  * #DOC	typedef srt_bool (*srt_set_it_s)(const srt_string *, void *context);
  *
- * Copyright (c) 2015-2019 F. Aragon. All rights reserved.
+ * Copyright (c) 2015-2020 F. Aragon. All rights reserved.
  * Released under the BSD 3-Clause License (see the doc/LICENSE)
  */
 
@@ -51,6 +59,8 @@ enum eSMS_Type {
 	SMS_I = SM0_I,
 	SMS_I32 = SM0_I32,
 	SMS_U32 = SM0_U32,
+	SMS_F = SM0_F,
+	SMS_D = SM0_D,
 	SMS_S = SM0_S
 };
 
@@ -60,6 +70,8 @@ typedef srt_map srt_set; /* Opaque structure (accessors are provided) */
 typedef srt_bool (*srt_set_it_i32)(int32_t k, void *context);
 typedef srt_bool (*srt_set_it_u32)(uint32_t k, void *context);
 typedef srt_bool (*srt_set_it_i)(int64_t k, void *context);
+typedef srt_bool (*srt_set_it_f)(float k, void *context);
+typedef srt_bool (*srt_set_it_d)(double k, void *context);
 typedef srt_bool (*srt_set_it_s)(const srt_string *, void *context);
 
 /*
@@ -155,20 +167,38 @@ S_INLINE srt_set *sms_cpy(srt_set **s, const srt_set *src)
  * Existence check
  */
 
-/* #API: |Set element count/check|set; 32-bit unsigned integer key|S_TRUE: element found; S_FALSE: not in the set|O(log n)|1;2| */
-S_INLINE srt_bool sms_count_u(const srt_set *s, uint32_t k)
+/* #API: |Set element count/check (SMS_U32)|set; key|S_TRUE: element found; S_FALSE: not in the set|O(log n)|1;2| */
+S_INLINE size_t sms_count_u32(const srt_set *s, uint32_t k)
 {
-	return sm_count_u(s, k);
+	return sm_count_u32(s, k);
 }
 
-/* #API: |Set element count/check|set; integer key|S_TRUE: element found; S_FALSE: not in the set|O(log n)|1;2| */
-S_INLINE srt_bool sms_count_i(const srt_set *s, int64_t k)
+/* #API: |Set element count/check (SMS_I32)|set; key|S_TRUE: element found; S_FALSE: not in the set|O(log n)|1;2| */
+S_INLINE size_t sms_count_i32(const srt_set *s, int32_t k)
+{
+	return sm_count_i32(s, k);
+}
+
+/* #API: |Set element count/check (SMS_I)|set; key|S_TRUE: element found; S_FALSE: not in the set|O(log n)|1;2| */
+S_INLINE size_t sms_count_i(const srt_set *s, int64_t k)
 {
 	return sm_count_i(s, k);
 }
 
-/* #API: |Set element count/check|set; string key|S_TRUE: element found; S_FALSE: not in the set|O(log n)|1;2| */
-S_INLINE srt_bool sms_count_s(const srt_set *s, const srt_string *k)
+/* #API: |Set element count/check (SMS_F)|set; key|S_TRUE: element found; S_FALSE: not in the set|O(log n)|1;2| */
+S_INLINE size_t sms_count_f(const srt_set *s, float k)
+{
+	return sm_count_f(s, k);
+}
+
+/* #API: |Set element count/check (SMS_D)|set; key|S_TRUE: element found; S_FALSE: not in the set|O(log n)|1;2| */
+S_INLINE size_t sms_count_d(const srt_set *s, double k)
+{
+	return sm_count_d(s, k);
+}
+
+/* #API: |Set element count/check (SMS_S)|set; key|S_TRUE: element found; S_FALSE: not in the set|O(log n)|1;2| */
+S_INLINE size_t sms_count_s(const srt_set *s, const srt_string *k)
 {
 	return sm_count_s(s, k);
 }
@@ -177,7 +207,7 @@ S_INLINE srt_bool sms_count_s(const srt_set *s, const srt_string *k)
  * Insert
  */
 
-/* #API: |Insert into int32-int32 set|set; key|S_TRUE: OK, S_FALSE: insertion error|O(log n)|1;2| */
+/* #API: |Insert element (SMS_I32)|set; key|S_TRUE: OK, S_FALSE: insertion error|O(log n)|1;2| */
 S_INLINE srt_bool sms_insert_i32(srt_set **s, int32_t k)
 {
 	struct SMapi n;
@@ -186,7 +216,7 @@ S_INLINE srt_bool sms_insert_i32(srt_set **s, int32_t k)
 	return st_insert((srt_tree **)s, (const srt_tnode *)&n);
 }
 
-/* #API: |Insert into uint32-uint32 set|set; key|S_TRUE: OK, S_FALSE: insertion error|O(log n)|1;2| */
+/* #API: |Insert element (SMS_U32)|set; key|S_TRUE: OK, S_FALSE: insertion error|O(log n)|1;2| */
 S_INLINE srt_bool sms_insert_u32(srt_set **s, uint32_t k)
 {
 	struct SMapu n;
@@ -195,7 +225,7 @@ S_INLINE srt_bool sms_insert_u32(srt_set **s, uint32_t k)
 	return st_insert((srt_tree **)s, (const srt_tnode *)&n);
 }
 
-/* #API: |Insert into int-int set|set; key|S_TRUE: OK, S_FALSE: insertion error|O(log n)|1;2| */
+/* #API: |Insert element (SMS_I)|set; key|S_TRUE: OK, S_FALSE: insertion error|O(log n)|1;2| */
 S_INLINE srt_bool sms_insert_i(srt_set **s, int64_t k)
 {
 	struct SMapI n;
@@ -204,7 +234,25 @@ S_INLINE srt_bool sms_insert_i(srt_set **s, int64_t k)
 	return st_insert((srt_tree **)s, (const srt_tnode *)&n);
 }
 
-/* #API: |Insert into string-string set|set; key|S_TRUE: OK, S_FALSE: insertion error|O(log n)|1;2| */
+/* #API: |Insert element (SMS_F)|set; key|S_TRUE: OK, S_FALSE: insertion error|O(log n)|1;2| */
+S_INLINE srt_bool sms_insert_f(srt_set **s, float k)
+{
+	struct SMapF n;
+	RETURN_IF(!s || (*s)->d.sub_type != SMS_F, S_FALSE);
+	n.k = k;
+	return st_insert((srt_tree **)s, (const srt_tnode *)&n);
+}
+
+/* #API: |Insert element (SMS_D)|set; key|S_TRUE: OK, S_FALSE: insertion error|O(log n)|1;2| */
+S_INLINE srt_bool sms_insert_d(srt_set **s, double k)
+{
+	struct SMapD n;
+	RETURN_IF(!s || (*s)->d.sub_type != SMS_D, S_FALSE);
+	n.k = k;
+	return st_insert((srt_tree **)s, (const srt_tnode *)&n);
+}
+
+/* #API: |Insert element (SMS_S)|set; key|S_TRUE: OK, S_FALSE: insertion error|O(log n)|1;2| */
 S_INLINE srt_bool sms_insert_s(srt_set **s, const srt_string *k)
 {
 	struct SMapS n;
@@ -228,13 +276,37 @@ S_INLINE srt_bool sms_insert_s(srt_set **s, const srt_string *k)
  * Delete
  */
 
-/* #API: |Delete set element|set; integer key|S_TRUE: found and deleted; S_FALSE: not found|O(log n)|1;2| */
+/* #API: |Delete element (SMS_I32)|set; key|S_TRUE: found and deleted; S_FALSE: not found|O(log n)|1;2| */
+S_INLINE srt_bool sms_delete_i32(srt_set *s, int32_t k)
+{
+	return sm_delete_i32(s, k);
+}
+
+/* #API: |Delete element (SMS_U32)|set; key|S_TRUE: found and deleted; S_FALSE: not found|O(log n)|1;2| */
+S_INLINE srt_bool sms_delete_u32(srt_set *s, uint32_t k)
+{
+	return sm_delete_u32(s, k);
+}
+
+/* #API: |Delete element (SMS_I)|set; key|S_TRUE: found and deleted; S_FALSE: not found|O(log n)|1;2| */
 S_INLINE srt_bool sms_delete_i(srt_set *s, int64_t k)
 {
 	return sm_delete_i(s, k);
 }
 
-/* #API: |Delete set element|set; string key|S_TRUE: found and deleted; S_FALSE: not found|O(log n)|1;2| */
+/* #API: |Delete element (SMS_F)|set; key|S_TRUE: found and deleted; S_FALSE: not found|O(log n)|1;2| */
+S_INLINE srt_bool sms_delete_f(srt_set *s, float k)
+{
+	return sm_delete_f(s, k);
+}
+
+/* #API: |Delete element (SMS_D)|set; key|S_TRUE: found and deleted; S_FALSE: not found|O(log n)|1;2| */
+S_INLINE srt_bool sms_delete_d(srt_set *s, double k)
+{
+	return sm_delete_d(s, k);
+}
+
+/* #API: |Delete element (SMS_S)|set; key|S_TRUE: found and deleted; S_FALSE: not found|O(log n)|1;2| */
 S_INLINE srt_bool sms_delete_s(srt_set *s, const srt_string *k)
 {
 	return sm_delete_s(s, k);
@@ -244,16 +316,22 @@ S_INLINE srt_bool sms_delete_s(srt_set *s, const srt_string *k)
  * Enumeration
  */
 
-/* #API: |Enumerate set elements in a given key range|set; key lower bound; key upper bound; callback function; callback function context|Elements processed|O(log n) + O(log m); additional 2 * O(log n) space required, allocated on the stack, i.e. fast|1;2| */
+/* #API: |Enumerate elements in a given key range (SMS_I32)|set; key lower bound; key upper bound; callback function; callback function context|Elements processed|O(log n) + O(log m); additional 2 * O(log n) space required, allocated on the stack, i.e. fast|1;2| */
 size_t sms_itr_i32(const srt_set *s, int32_t key_min, int32_t key_max, srt_set_it_i32 f, void *context);
 
-/* #API: |Enumerate set elements in a given key range|set; key lower bound; key upper bound; callback function; callback function context|Elements processed|O(log n) + O(log m); additional 2 * O(log n) space required, allocated on the stack, i.e. fast|1;2| */
+/* #API: |Enumerate elements in a given key range (SMS_U32)|set; key lower bound; key upper bound; callback function; callback function context|Elements processed|O(log n) + O(log m); additional 2 * O(log n) space required, allocated on the stack, i.e. fast|1;2| */
 size_t sms_itr_u32(const srt_set *s, uint32_t key_min, uint32_t key_max, srt_set_it_u32 f, void *context);
 
-/* #API: |Enumerate set elements in a given key range|set; key lower bound; key upper bound; callback function; callback function context|Elements processed|O(log n) + O(log m); additional 2 * O(log n) space required, allocated on the stack, i.e. fast|1;2| */
+/* #API: |Enumerate elements in a given key range (SMS_I)|set; key lower bound; key upper bound; callback function; callback function context|Elements processed|O(log n) + O(log m); additional 2 * O(log n) space required, allocated on the stack, i.e. fast|1;2| */
 size_t sms_itr_i(const srt_set *s, int64_t key_min, int64_t key_max, srt_set_it_i f, void *context);
 
-/* #API: |Enumerate set elements in a given key range|set; key lower bound; key upper bound; callback function; callback function context|Elements processed|O(log n) + O(log m); additional 2 * O(log n) space required, allocated on the stack, i.e. fast|1;2| */
+/* #API: |Enumerate elements in a given key range (SMS_F)|set; key lower bound; key upper bound; callback function; callback function context|Elements processed|O(log n) + O(log m); additional 2 * O(log n) space required, allocated on the stack, i.e. fast|1;2| */
+size_t sms_itr_f(const srt_set *s, float key_min, float key_max, srt_set_it_f f, void *context);
+
+/* #API: |Enumerate elements in a given key range (SMS_D)|set; key lower bound; key upper bound; callback function; callback function context|Elements processed|O(log n) + O(log m); additional 2 * O(log n) space required, allocated on the stack, i.e. fast|1;2| */
+size_t sms_itr_d(const srt_set *s, double key_min, double key_max, srt_set_it_d f, void *context);
+
+/* #API: |Enumerate elements in a given key range (SMS_S)|set; key lower bound; key upper bound; callback function; callback function context|Elements processed|O(log n) + O(log m); additional 2 * O(log n) space required, allocated on the stack, i.e. fast|1;2| */
 size_t sms_itr_s(const srt_set *s, const srt_string *key_min, const srt_string *key_max, srt_set_it_s f, void *context);
 
 /*
@@ -261,22 +339,32 @@ size_t sms_itr_s(const srt_set *s, const srt_string *key_min, const srt_string *
  * as array access after compiler optimization.
  */
 
-/* #API: |Enumerate int32 set|set; element, 0 to n - 1|int32_t|O(1)|1;2|
+/* #API: |Enumerate elements (SMS_I32)|set; element, 0 to n - 1|int32_t|O(1)|1;2|
 int32_t sms_it_i32(const srt_set *s, srt_tndx i);
 */
 #define sms_it_i32(s, i) sm_it_i32_k(s, i)
 
-/* #API: |Enumerate uint32 set|set; element, 0 to n - 1|uint32_t|O(1)|1;2|
+/* #API: |Enumerate elements (SMS_U32)|set; element, 0 to n - 1|uint32_t|O(1)|1;2|
 uint32_t sms_it_u32(const srt_set *s, srt_tndx i);
 */
 #define sms_it_u32(s, i) sm_it_u32_k(s, i)
 
-/* #API: |Enumerate int64 set|set; element, 0 to n - 1|int64_t|O(1)|1;2|
-int32_t sms_it_i32(const srt_set *s, srt_tndx i);
+/* #API: |Enumerate elements (SMS_I)|set; element, 0 to n - 1|int64_t|O(1)|1;2|
+int32_t sms_it_i(const srt_set *s, srt_tndx i);
 */
 #define sms_it_i(s, i) sm_it_i_k(s, i)
 
-/* #API: |Enumerate string set|set; element, 0 to n - 1|string|O(1)|1;2|
+/* #API: |Enumerate elements (SMS_F)|set; element, 0 to n - 1|float|O(1)|1;2|
+float sms_it_f(const srt_set *s, srt_tndx i);
+*/
+#define sms_it_f(s, i) sm_it_f_k(s, i)
+
+/* #API: |Enumerate elements (SMS_D)|set; element, 0 to n - 1|double|O(1)|1;2|
+double sms_it_d(const srt_set *s, srt_tndx i);
+*/
+#define sms_it_d(s, i) sm_it_d_k(s, i)
+
+/* #API: |Enumerate elements (SMS_S)|set; element, 0 to n - 1|string|O(1)|1;2|
 int32_t sms_it_s(const srt_set *s, srt_tndx i);
 */
 #define sms_it_s(s, i) sm_it_s_k(s, i)

--- a/src/svector.c
+++ b/src/svector.c
@@ -3,7 +3,7 @@
  *
  * Vector handling.
  *
- * Copyright (c) 2015-2019 F. Aragon. All rights reserved.
+ * Copyright (c) 2015-2020 F. Aragon. All rights reserved.
  * Released under the BSD 3-Clause License (see the doc/LICENSE)
  */
 
@@ -16,6 +16,12 @@
 #endif
 #ifndef SV_DEFAULT_UNSIGNED_VAL
 #define SV_DEFAULT_UNSIGNED_VAL 0
+#endif
+#ifndef SV_DEFAULT_FLOAT_VAL
+#define SV_DEFAULT_FLOAT_VAL 0.0
+#endif
+#ifndef SV_DEFAULT_DOUBLE_VAL
+#define SV_DEFAULT_DOUBLE_VAL 0.0
 #endif
 
 /*
@@ -32,92 +38,37 @@ static srt_vector *sv_check(srt_vector **v);
 #define sv_void (srt_vector *)sd_void
 
 /*
- * Push-related function pointers
- */
-
-#define SV_STx(f, TS, TL)                                                      \
-	static void f(void *st, TL *c)                                         \
-	{                                                                      \
-		*(TS *)(st) = (TS) * (c);                                      \
-	}
-
-/* clang-format off */
-SV_STx(svsti8, char, const int64_t)
-SV_STx(svstu8, unsigned char, const uint64_t)
-SV_STx(svsti16, short, const int64_t)
-SV_STx(svstu16, unsigned short, const uint64_t)
-SV_STx(svsti32, int32_t, const int64_t)
-SV_STx(svstu32, uint32_t, const uint64_t)
-SV_STx(svsti64, int64_t, const int64_t)
-SV_STx(svstu64, uint64_t, const uint64_t)
-typedef void (*T_SVSTX)(void *, const int64_t *);
-/* clang-format on */
-
-static T_SVSTX svstx_f[SV_LAST_INT + 1] = {
-	svsti8,  (T_SVSTX)svstu8,  svsti16, (T_SVSTX)svstu16,
-	svsti32, (T_SVSTX)svstu32, svsti64, (T_SVSTX)svstu64};
-
-/*
- * Pop-related function pointers
- */
-
-#define SV_LDx(f, TL, TO)                                                      \
-	static TO f(const void *ld, size_t index)                              \
-	{                                                                      \
-		return (TO)(((TL *)ld)[index]);                                \
-	}
-
-/* clang-format off */
-SV_LDx(svldi8, const signed char, int64_t)
-SV_LDx(svldu8, const unsigned char, uint64_t)
-SV_LDx(svldi16, const short, int64_t)
-SV_LDx(svldu16, const unsigned short, uint64_t)
-SV_LDx(svldi32, const int32_t, int64_t)
-SV_LDx(svldu32, const uint32_t, uint64_t)
-SV_LDx(svldi64, const int64_t, int64_t)
-SV_LDx(svldu64, const uint64_t, uint64_t)
-typedef int64_t (*T_SVLDX)(const void *, size_t);
-/* clang-format on */
-
-static T_SVLDX svldx_f[SV_LAST_INT + 1] = {
-	svldi8,  (T_SVLDX)svldu8,  svldi16, (T_SVLDX)svldu16,
-	svldi32, (T_SVLDX)svldu32, svldi64, (T_SVLDX)svldu64};
-
-/*
  * Internal functions
  */
 
-#define BUILD_CMP_I(FN, T)                                                     \
+#define BUILD_CMP(FN, T)                                                       \
 	static int FN(const void *a, const void *b)                            \
 	{                                                                      \
-		int64_t r = *((const T *)a) - *((const T *)b);                 \
-		return r < 0 ? -1 : r > 0 ? 1 : 0;                             \
+		T a2, b2;                                                      \
+		memcpy(&a2, a, sizeof(T));                                     \
+		memcpy(&b2, b, sizeof(T));                                     \
+		return a2 < b2 ? -1 : a2 > b2 ? 1 : 0;                         \
 	}
 
-#define BUILD_CMP_U(FN, T)                                                     \
-	static int FN(const void *a, const void *b)                            \
-	{                                                                      \
-		T a2 = *((const T *)a), b2 = *((const T *)b);                  \
-		return a2 < b2 ? -1 : a2 == b2 ? 0 : 1;                        \
-	}
+BUILD_CMP(__sv_cmp_i8, int8_t)
+BUILD_CMP(__sv_cmp_i16, int16_t)
+BUILD_CMP(__sv_cmp_i32, int32_t)
+BUILD_CMP(__sv_cmp_i64, int64_t)
+BUILD_CMP(__sv_cmp_u8, uint8_t)
+BUILD_CMP(__sv_cmp_u16, uint16_t)
+BUILD_CMP(__sv_cmp_u32, uint32_t)
+BUILD_CMP(__sv_cmp_u64, uint64_t)
+BUILD_CMP(__sv_cmp_f, float)
+BUILD_CMP(__sv_cmp_d, double)
 
-BUILD_CMP_I(__sv_cmp_i8, signed char)
-BUILD_CMP_I(__sv_cmp_i16, short)
-BUILD_CMP_I(__sv_cmp_i32, int)
-BUILD_CMP_I(__sv_cmp_i64, int64_t)
-BUILD_CMP_U(__sv_cmp_u8, unsigned char)
-BUILD_CMP_U(__sv_cmp_u16, unsigned short)
-BUILD_CMP_U(__sv_cmp_u32, unsigned int)
-BUILD_CMP_U(__sv_cmp_u64, uint64_t)
+static uint8_t svt_sizes[SV_LAST_NUM + 1] = {
+	sizeof(int8_t),  sizeof(uint8_t),  sizeof(int16_t), sizeof(uint16_t),
+	sizeof(int32_t), sizeof(uint32_t), sizeof(int64_t), sizeof(uint64_t),
+	sizeof(float),   sizeof(double)};
 
-static uint8_t svt_sizes[SV_LAST_INT + 1] = {
-	sizeof(char),		sizeof(unsigned char), sizeof(short),
-	sizeof(unsigned short), sizeof(int),	   sizeof(unsigned int),
-	sizeof(int64_t),	sizeof(uint64_t)};
-
-static srt_vector_cmp svt_cmpf[SV_LAST_INT + 1] = {
-	__sv_cmp_i8,  __sv_cmp_u8,  __sv_cmp_i16, __sv_cmp_u16,
-	__sv_cmp_i32, __sv_cmp_u32, __sv_cmp_i64, __sv_cmp_u64};
+static srt_vector_cmp svt_cmpf[SV_LAST_NUM + 1] = {
+	__sv_cmp_i8,  __sv_cmp_u8,  __sv_cmp_i16, __sv_cmp_u16, __sv_cmp_i32,
+	__sv_cmp_u32, __sv_cmp_i64, __sv_cmp_u64, __sv_cmp_f,   __sv_cmp_d};
 
 static srt_vector *sv_alloc_base(enum eSV_Type t, size_t elem_size,
 				 size_t init_size, const srt_vector_cmp f)
@@ -322,7 +273,7 @@ static const char *ptr_to_elem_r(const srt_vector *v, size_t i)
 
 uint8_t sv_elem_size(enum eSV_Type t)
 {
-	return t > SV_LAST_INT ? 0 : svt_sizes[t];
+	return t > SV_LAST_NUM ? 0 : svt_sizes[t];
 }
 
 /*
@@ -339,7 +290,7 @@ srt_vector *sv_alloc_raw(enum eSV_Type t, srt_bool ext_buf, void *buffer,
 	sd_reset((srt_data *)v, sizeof(srt_vector), elem_size, max_size,
 		 ext_buf, S_FALSE);
 	v->d.sub_type = (uint8_t)t;
-	v->vx.cmpf = t <= SV_LAST_INT ? svt_cmpf[t] : f;
+	v->vx.cmpf = t <= SV_LAST_NUM ? svt_cmpf[t] : f;
 	return v;
 }
 
@@ -494,7 +445,8 @@ srt_vector *sv_sort(srt_vector *v)
  * Search
  */
 
-size_t sv_find(const srt_vector *v, size_t off, const void *target)
+static size_t sv_find_aux(const srt_vector *v, size_t off, const void *tgt,
+			  size_t tgt_size)
 {
 	size_t pos, size, elem_size, off_max, i;
 	const void *p;
@@ -503,74 +455,36 @@ size_t sv_find(const srt_vector *v, size_t off, const void *target)
 	size = sv_size(v);
 	p = sv_get_buffer_r(v);
 	elem_size = v->d.elem_size;
-	RETURN_IF(!elem_size, S_NPOS);
+	RETURN_IF(!elem_size || (tgt_size && elem_size != tgt_size), S_NPOS);
 	off_max = size * v->d.elem_size;
 	i = off * elem_size;
 	for (; i < off_max; i += elem_size)
-		if (!memcmp((const char *)p + i, target, elem_size))
+		if (!memcmp((const char *)p + i, tgt, elem_size))
 			return i / elem_size; /* found */
 	return pos;
 }
 
-#define SV_FIND_iu(v, off, target)                                             \
-	char i8;                                                               \
-	unsigned char u8;                                                      \
-	short i16;                                                             \
-	unsigned short u16;                                                    \
-	int i32;                                                               \
-	unsigned u32;                                                          \
-	int64_t i64;                                                           \
-	uint64_t u64;                                                          \
-	void *src;                                                             \
-	RETURN_IF(!v || v->d.sub_type > SV_U64, S_NPOS);                       \
-	switch (v->d.sub_type) {                                               \
-	case SV_I8:                                                            \
-		i8 = (char)target;                                             \
-		src = &i8;                                                     \
-		break;                                                         \
-	case SV_U8:                                                            \
-		u8 = (unsigned char)target;                                    \
-		src = &u8;                                                     \
-		break;                                                         \
-	case SV_I16:                                                           \
-		i16 = (short)target;                                           \
-		src = &i16;                                                    \
-		break;                                                         \
-	case SV_U16:                                                           \
-		u16 = (unsigned short)target;                                  \
-		src = &u16;                                                    \
-		break;                                                         \
-	case SV_I32:                                                           \
-		i32 = (int)target;                                             \
-		src = &i32;                                                    \
-		break;                                                         \
-	case SV_U32:                                                           \
-		u32 = (unsigned)target;                                        \
-		src = &u32;                                                    \
-		break;                                                         \
-	case SV_I64:                                                           \
-		i64 = (int64_t)target;                                         \
-		src = &i64;                                                    \
-		break;                                                         \
-	case SV_U64:                                                           \
-		u64 = (uint64_t)target;                                        \
-		src = &u64;                                                    \
-		break;                                                         \
-	default:                                                               \
-		src = NULL;                                                    \
+size_t sv_find(const srt_vector *v, size_t off, const void *target)
+{
+	return sv_find_aux(v, off, target, 0);
+}
+
+#define SV_BUILD_FIND(FN, T)                                                   \
+	size_t FN(const srt_vector *v, size_t off, const T target)             \
+	{                                                                      \
+		return sv_find_aux(v, off, &target, sizeof(target));           \
 	}
 
-size_t sv_find_i(const srt_vector *v, size_t off, int64_t target)
-{
-	SV_FIND_iu(v, off, target);
-	return sv_find(v, off, src);
-}
-
-size_t sv_find_u(const srt_vector *v, size_t off, uint64_t target)
-{
-	SV_FIND_iu(v, off, target);
-	return sv_find(v, off, src);
-}
+SV_BUILD_FIND(sv_find_i8, int8_t)
+SV_BUILD_FIND(sv_find_u8, uint8_t)
+SV_BUILD_FIND(sv_find_i16, int16_t)
+SV_BUILD_FIND(sv_find_u16, uint16_t)
+SV_BUILD_FIND(sv_find_i32, int32_t)
+SV_BUILD_FIND(sv_find_u32, uint32_t)
+SV_BUILD_FIND(sv_find_i64, int64_t)
+SV_BUILD_FIND(sv_find_u64, uint64_t)
+SV_BUILD_FIND(sv_find_f, float)
+SV_BUILD_FIND(sv_find_d, double)
 
 /*
  * Compare
@@ -618,102 +532,90 @@ const void *sv_at(const srt_vector *v, size_t index)
 	return (const void *)ptr_to_elem_r(v, index);
 }
 
-#define SV_AT_INT_CHECK(v)                                                     \
-	RETURN_IF(v->d.sub_type > SV_LAST_INT, SV_DEFAULT_SIGNED_VAL)
-
-#define SV_IU_AT(T, def_val)                                                   \
-	size_t size;                                                           \
-	const void *p;                                                         \
-	RETURN_IF(!v, def_val);                                                \
-	SV_AT_INT_CHECK(v);                                                    \
-	size = sv_size(v);                                                     \
-	RETURN_IF(index >= size, def_val);                                     \
-	p = sv_get_buffer_r(v);                                                \
-	return (T)(svldx_f[(int)v->d.sub_type](p, index));
-
-int64_t sv_at_i(const srt_vector *v, size_t index)
-{
-	SV_IU_AT(int64_t, SV_DEFAULT_SIGNED_VAL);
-}
-
-uint64_t sv_at_u(const srt_vector *v, size_t index)
-{
-	SV_IU_AT(uint64_t, SV_DEFAULT_UNSIGNED_VAL);
-}
-
-#undef SV_IU_AT
-
-	/*
-	 * Vector "set": set element value at given position
-	 */
-
-#define SV_SET_CHECK(v, index)                                                 \
-	RETURN_IF(!v || !*v, S_FALSE);                                         \
-	if (index >= sv_size(*v)) {                                            \
-		size_t new_size = index + 1;                                   \
-		RETURN_IF(sv_reserve(v, new_size) < new_size, S_FALSE);        \
-		sv_set_size(*v, new_size);                                     \
+#define SV_BUILD_AT(FN, T, DEF)                                                \
+	T FN(const srt_vector *v, size_t index)                                \
+	{                                                                      \
+		T acc;                                                         \
+		const void *p;                                                 \
+		p = v ? ptr_to_elem_r(v, index) : NULL;                        \
+		RETURN_IF(!v, DEF);                                            \
+		memcpy(&acc, p, sizeof(acc));                                  \
+		return acc;                                                    \
 	}
 
-#define SV_SET_INT_CHECK(v, index)                                             \
-	SV_SET_CHECK(v, index)                                                 \
-	RETURN_IF((*v)->d.sub_type > SV_LAST_INT, SV_DEFAULT_SIGNED_VAL)
+SV_BUILD_AT(sv_at_i8, int8_t, SV_DEFAULT_SIGNED_VAL)
+SV_BUILD_AT(sv_at_u8, uint8_t, SV_DEFAULT_UNSIGNED_VAL)
+SV_BUILD_AT(sv_at_i16, int16_t, SV_DEFAULT_SIGNED_VAL)
+SV_BUILD_AT(sv_at_u16, uint16_t, SV_DEFAULT_UNSIGNED_VAL)
+SV_BUILD_AT(sv_at_i32, int32_t, SV_DEFAULT_SIGNED_VAL)
+SV_BUILD_AT(sv_at_u32, uint32_t, SV_DEFAULT_UNSIGNED_VAL)
+SV_BUILD_AT(sv_at_i64, int64_t, SV_DEFAULT_SIGNED_VAL)
+SV_BUILD_AT(sv_at_u64, uint64_t, SV_DEFAULT_UNSIGNED_VAL)
+SV_BUILD_AT(sv_at_f, float, SV_DEFAULT_FLOAT_VAL)
+SV_BUILD_AT(sv_at_d, double, SV_DEFAULT_DOUBLE_VAL)
 
-srt_bool sv_set(srt_vector **v, size_t index, const void *value)
+/*
+ * Vector "set": set element value at given position
+ */
+
+static srt_bool sv_set_aux(srt_vector **v, size_t index, const void *value,
+			   size_t value_size)
 {
-	RETURN_IF(!value, S_FALSE);
-	SV_SET_CHECK(v, index);
+	RETURN_IF(!v || !*v || !value
+			  || (value_size && value_size != (*v)->d.elem_size),
+		  S_FALSE);
+	if (index >= sv_size(*v)) {
+		size_t new_size = index + 1;
+		RETURN_IF(sv_reserve(v, new_size) < new_size, S_FALSE);
+		sv_set_size(*v, new_size);
+	}
 	memcpy(ptr_to_elem(*v, index), value, (*v)->d.elem_size);
 	return S_TRUE;
 }
 
-#define SV_IU_SET(v, index, val)                                               \
-	SV_SET_INT_CHECK(v, index)                                             \
-	svstx_f[(int)(*v)->d.sub_type](ptr_to_elem(*v, index),                 \
-				       (const int64_t *)&val);
-
-srt_bool sv_set_i(srt_vector **v, size_t index, int64_t value)
+srt_bool sv_set(srt_vector **v, size_t index, const void *value)
 {
-	SV_IU_SET(v, index, value);
-	return S_TRUE;
+	return sv_set_aux(v, index, value, 0);
 }
 
-srt_bool sv_set_u(srt_vector **v, size_t index, uint64_t value)
+#define SV_BUILD_SET(FN, T)                                                    \
+	srt_bool FN(srt_vector **v, size_t index, const T value)               \
+	{                                                                      \
+		return sv_set_aux(v, index, &value, sizeof(value));            \
+	}
+
+SV_BUILD_SET(sv_set_i8, int8_t)
+SV_BUILD_SET(sv_set_u8, uint8_t)
+SV_BUILD_SET(sv_set_i16, int16_t)
+SV_BUILD_SET(sv_set_u16, uint16_t)
+SV_BUILD_SET(sv_set_i32, int32_t)
+SV_BUILD_SET(sv_set_u32, uint32_t)
+SV_BUILD_SET(sv_set_i64, int64_t)
+SV_BUILD_SET(sv_set_u64, uint64_t)
+SV_BUILD_SET(sv_set_f, float)
+SV_BUILD_SET(sv_set_d, double)
+
+/*
+ * Vector "push": add element in the last position
+ */
+
+static srt_bool sv_push_raw0(srt_vector **v, const void *src, size_t n,
+			     size_t elem_size)
 {
-	SV_IU_SET(v, index, value);
-	return S_TRUE;
-}
-
-#undef SV_IU_SET
-#undef SV_SET_CHECK
-#undef SV_SET_INT_CHECK
-
-	/*
-	 * Vector "push": add element in the last position
-	 */
-
-#define SV_PUSH_GROW(v, n) RETURN_IF(!v || !sv_grow(v, n), S_FALSE);
-#define SV_INT_CHECK(v) RETURN_IF((*v)->d.sub_type > SV_LAST_INT, S_FALSE);
-#define SV_PUSH_START_VARS                                                     \
-	size_t sz;                                                             \
-	char *p
-#define SV_PUSH_START(v)                                                       \
-	sz = sv_size(*v);                                                      \
+	char *p;
+	size_t sz;
+	RETURN_IF(!src || !n || !v || !sv_grow(v, n), S_FALSE);
+	sz = sv_size(*v);
 	p = ptr_to_elem(*v, sz);
-
-#define SV_PUSH_END(v, n) sv_set_size(*v, sz + n);
+	sv_set_size(*v, sz + n);
+	RETURN_IF(elem_size && elem_size != (*v)->d.elem_size, S_FALSE);
+	memcpy(p, src, (*v)->d.elem_size * n);
+	return S_TRUE;
+}
 
 srt_bool sv_push_raw(srt_vector **v, const void *src, size_t n)
 {
-	SV_PUSH_START_VARS;
-	size_t elem_size;
-	RETURN_IF(!src || !n, S_FALSE);
-	SV_PUSH_GROW(v, n);
-	SV_PUSH_START(v);
-	SV_PUSH_END(v, n);
-	elem_size = (*v)->d.elem_size;
-	memcpy(p, src, elem_size * n);
-	return S_TRUE;
+	return sv_push_raw0(v, src, n, 0);
 }
 
 size_t sv_push_aux(srt_vector **v, const void *c1, ...)
@@ -726,7 +628,7 @@ size_t sv_push_aux(srt_vector **v, const void *c1, ...)
 	va_start(ap, c1);
 	next = c1;
 	while (!s_varg_tail_ptr_tag(next)) { /* last element tag */
-		if (next && sv_push_raw(v, next, 1))
+		if (next && sv_push_raw0(v, next, 1, 0))
 			op_cnt++;
 		next = (void *)va_arg(ap, void *);
 	}
@@ -734,67 +636,56 @@ size_t sv_push_aux(srt_vector **v, const void *c1, ...)
 	return op_cnt;
 }
 
-srt_bool sv_push_i(srt_vector **v, int64_t c)
-{
-	SV_PUSH_START_VARS;
-	SV_PUSH_GROW(v, 1);
-	SV_INT_CHECK(v);
-	SV_PUSH_START(v);
-	SV_PUSH_END(v, 1);
-	svstx_f[(int)(*v)->d.sub_type](p, &c);
-	return S_TRUE;
-}
+#define SV_BUILD_PUSH(FN, T)                                                   \
+	srt_bool FN(srt_vector **v, const T value)                             \
+	{                                                                      \
+		return sv_push_raw0(v, &value, 1, sizeof(value));              \
+	}
 
-srt_bool sv_push_u(srt_vector **v, uint64_t c)
-{
-	SV_PUSH_START_VARS;
-	SV_PUSH_GROW(v, 1);
-	SV_INT_CHECK(v);
-	SV_PUSH_START(v);
-	SV_PUSH_END(v, 1);
-	svstx_f[(int)(*v)->d.sub_type](p, (const int64_t *)&c);
-	return S_TRUE;
-}
+SV_BUILD_PUSH(sv_push_i8, int8_t)
+SV_BUILD_PUSH(sv_push_u8, uint8_t)
+SV_BUILD_PUSH(sv_push_i16, int16_t)
+SV_BUILD_PUSH(sv_push_u16, uint16_t)
+SV_BUILD_PUSH(sv_push_i32, int32_t)
+SV_BUILD_PUSH(sv_push_u32, uint32_t)
+SV_BUILD_PUSH(sv_push_i64, int64_t)
+SV_BUILD_PUSH(sv_push_u64, uint64_t)
+SV_BUILD_PUSH(sv_push_f, float)
+SV_BUILD_PUSH(sv_push_d, double)
 
-#undef SV_PUSH_START
-#undef SV_PUSH_END
-#undef SV_PUSH_IU
-
-	/*
-	 * Vector "pop": extract element from last position
-	 */
-
-#define SV_POP_START(def_val)                                                  \
-	size_t sz;                                                             \
-	char *p;                                                               \
-	ASSERT_RETURN_IF(!v, def_val);                                         \
-	sz = sv_size(v);                                                       \
-	ASSERT_RETURN_IF(!sz, def_val);                                        \
-	p = ptr_to_elem(v, sz - 1);
-
-#define SV_POP_END sv_set_size(v, sz - 1);
-
-#define SV_POP_IU(T)                                                           \
-	SV_AT_INT_CHECK(v);                                                    \
-	return (T)(svldx_f[(int)v->d.sub_type](p, 0));
+/*
+ * Vector "pop": extract element from last position
+ */
 
 void *sv_pop(srt_vector *v)
 {
-	SV_POP_START(NULL);
-	SV_POP_END;
+	char *p;
+	size_t sz;
+	ASSERT_RETURN_IF(!v, NULL);
+	sz = sv_size(v);
+	ASSERT_RETURN_IF(!sz, NULL);
+	p = ptr_to_elem(v, sz - 1);
+	sv_set_size(v, sz - 1);
 	return p;
 }
 
-int64_t sv_pop_i(srt_vector *v)
-{
-	SV_POP_START(SV_DEFAULT_SIGNED_VAL);
-	SV_POP_END;
-	SV_POP_IU(int64_t);
-}
+#define SV_BUILD_POP(FN, T, DEF_VAL)                                           \
+	T FN(srt_vector *v)                                                    \
+	{                                                                      \
+		T acc;                                                         \
+		void *p = sv_pop(v);                                           \
+		RETURN_IF(!p, DEF_VAL);                                        \
+		memcpy(&acc, p, sizeof(T));                                    \
+		return acc;                                                    \
+	}
 
-uint64_t sv_pop_u(srt_vector *v)
-{
-	SV_POP_START(SV_DEFAULT_UNSIGNED_VAL);
-	SV_POP_END;
-	SV_POP_IU(uint64_t);
-}
+SV_BUILD_POP(sv_pop_i8, int8_t, SV_DEFAULT_SIGNED_VAL)
+SV_BUILD_POP(sv_pop_u8, uint8_t, SV_DEFAULT_UNSIGNED_VAL)
+SV_BUILD_POP(sv_pop_i16, int16_t, SV_DEFAULT_SIGNED_VAL)
+SV_BUILD_POP(sv_pop_u16, uint16_t, SV_DEFAULT_UNSIGNED_VAL)
+SV_BUILD_POP(sv_pop_i32, int32_t, SV_DEFAULT_SIGNED_VAL)
+SV_BUILD_POP(sv_pop_u32, uint32_t, SV_DEFAULT_UNSIGNED_VAL)
+SV_BUILD_POP(sv_pop_i64, int64_t, SV_DEFAULT_SIGNED_VAL)
+SV_BUILD_POP(sv_pop_u64, uint64_t, SV_DEFAULT_UNSIGNED_VAL)
+SV_BUILD_POP(sv_pop_f, float, SV_DEFAULT_FLOAT_VAL)
+SV_BUILD_POP(sv_pop_d, double, SV_DEFAULT_DOUBLE_VAL)

--- a/src/svector.h
+++ b/src/svector.h
@@ -11,8 +11,33 @@ extern "C" {
  *
  * #DOC Vector handling functions for managing integer data and
  * #DOC generic data.
+ * #DOC
+ * #DOC Supported vector types (enum eSV_Type):
+ * #DOC
+ * #DOC
+ * #DOC SV_I8: int8_t
+ * #DOC
+ * #DOC SV_U8: uint8_t
+ * #DOC
+ * #DOC SV_I16: int16_t
+ * #DOC
+ * #DOC SV_U16: uint16_t
+ * #DOC
+ * #DOC SV_I32: int32_t
+ * #DOC
+ * #DOC SV_U32: uint32_t
+ * #DOC
+ * #DOC SV_I64: int64_t
+ * #DOC
+ * #DOC SV_U64: uint64_t
+ * #DOC
+ * #DOC SV_F: float
+ * #DOC
+ * #DOC SV_D: double
+ * #DOC
+ * #DOC SV_GEN: generic-data (user defined)
  *
- * Copyright (c) 2015-2019 F. Aragon. All rights reserved.
+ * Copyright (c) 2015-2020 F. Aragon. All rights reserved.
  * Released under the BSD 3-Clause License (see the doc/LICENSE)
  */
 
@@ -23,8 +48,7 @@ extern "C" {
  */
 
 enum eSV_Type {
-	SV_FIRST,
-	SV_I8 = SV_FIRST,
+	SV_I8 = 0,
 	SV_U8,
 	SV_I16,
 	SV_U16,
@@ -32,7 +56,9 @@ enum eSV_Type {
 	SV_U32,
 	SV_I64,
 	SV_U64,
-	SV_LAST_INT = SV_U64,
+	SV_F,
+	SV_D,
+	SV_LAST_NUM = SV_D,
 	SV_GEN
 };
 
@@ -70,13 +96,6 @@ typedef struct SVector
  * Allocation
  */
 
-/*
-#API: |Allocate typed vector (stack)|Vector type: SV_I8/SV_U8/SV_I16/SV_U16/SV_I32/SV_U32/SV_I64/SV_U64; space preallocated to store n elements|vector|O(1)|1;2|
-srt_vector *sv_alloca_t(enum eSV_Type t, size_t initial_num_elems_reserve)
-
-#API: |Allocate generic vector (stack)|element size; space preallocated to store n elements; compare function (used for sorting, pass NULL for none)|vector|O(1)|1;2|
-srt_vector *sv_alloca(size_t elem_size, size_t initial_num_elems_reserve, const srt_vector_cmp f)
-*/
 #define sv_alloca(elem_size, max_size, cmp_f)                                  \
 	sv_alloc_raw(SV_GEN, S_TRUE,                                           \
 		     s_alloca(sd_alloc_size_raw(sizeof(srt_vector), elem_size, \
@@ -93,16 +112,19 @@ srt_vector *sv_alloc_raw(enum eSV_Type t, srt_bool ext_buf,
 			 void *buffer, size_t elem_size,
 			 size_t max_size, const srt_vector_cmp f);
 
-/* #API: |Allocate generic vector (heap)|element size; space preallocated to store n elements; compare function (used for sorting, pass NULL for none)|vector|O(1)|1;2| */
+/* #API: |Allocate SV_GEN vector (heap)|element size; space preallocated to store n elements; compare function (used for sorting, pass NULL for none)|vector|O(1)|1;2| */
 srt_vector *sv_alloc(size_t elem_size, size_t initial_num_elems_reserve, const srt_vector_cmp f);
 
-/* #API: |Allocate typed vector (heap)|Vector type: SV_I8/SV_U8/SV_I16/SV_U16/SV_I32/SV_U32/SV_I64/SV_U64; space preallocated to store n elements|vector|O(1)|1;2| */
+/* #API: |Allocate typed vector (heap)|Vector type; space preallocated to store n elements|vector|O(1)|1;2| */
 srt_vector *sv_alloc_t(enum eSV_Type t, size_t initial_num_elems_reserve);
 
 SD_BUILDFUNCS_FULL(sv, srt_vector, 0)
 
 /*
-#API: |Allocate vector (stack)|space preallocated to store n elements|allocated vector|O(1)|1;2|
+#API: |Allocate typed vector (stack)|Vector type; space preallocated to store n elements|vector|O(1)|1;2|
+srt_vector *sv_alloca_t(enum eSV_Type t, size_t initial_num_elems_reserve)
+
+#API: |Allocate SV_GEN vector (stack)|space preallocated to store n elements|allocated vector|O(1)|1;2|
 srt_vector *sv_alloca(size_t initial_reserve)
 
 #API: |Free one or more vectors (heap)|vector;more vectors (optional)|-|O(1)|1;2|
@@ -214,14 +236,38 @@ srt_vector *sv_sort(srt_vector *v);
  * Search
  */
 
-/* #API: |Find value in vector (generic data)|vector; search offset start; target to be located|offset: >=0 found; S_NPOS: not found|O(n)|1;2| */
+/* #API: |Find value in vector (SV_GEN)|vector; search offset start; target to be located|offset: >=0 found; S_NPOS: not found|O(n)|1;2| */
 size_t sv_find(const srt_vector *v, size_t off, const void *target);
 
-/* #API: |Find value in vector (integer)|vector; search offset start; target to be located|offset: >=0 found; S_NPOS: not found|O(n)|1;2| */
-size_t sv_find_i(const srt_vector *v, size_t off, int64_t target);
+/* #API: |Find value in vector (SV_I8)|vector; search offset start; target to be located|offset: >=0 found; S_NPOS: not found|O(n)|1;2| */
+size_t sv_find_i8(const srt_vector *v, size_t off, int8_t target);
 
-/* #API: |Find value in vector (unsigned integer)|vector; search offset start; target to be located|offset: >=0 found; S_NPOS: not found|O(n)|1;2| */
-size_t sv_find_u(const srt_vector *v, size_t off, uint64_t target);
+/* #API: |Find value in vector (SV_U8)|vector; search offset start; target to be located|offset: >=0 found; S_NPOS: not found|O(n)|1;2| */
+size_t sv_find_u8(const srt_vector *v, size_t off, uint8_t target);
+
+/* #API: |Find value in vector (SV_I16)|vector; search offset start; target to be located|offset: >=0 found; S_NPOS: not found|O(n)|1;2| */
+size_t sv_find_i16(const srt_vector *v, size_t off, int16_t target);
+
+/* #API: |Find value in vector (SV_U16)|vector; search offset start; target to be located|offset: >=0 found; S_NPOS: not found|O(n)|1;2| */
+size_t sv_find_u16(const srt_vector *v, size_t off, uint16_t target);
+
+/* #API: |Find value in vector (SV_I32)|vector; search offset start; target to be located|offset: >=0 found; S_NPOS: not found|O(n)|1;2| */
+size_t sv_find_i32(const srt_vector *v, size_t off, int32_t target);
+
+/* #API: |Find value in vector (SV_U32)|vector; search offset start; target to be located|offset: >=0 found; S_NPOS: not found|O(n)|1;2| */
+size_t sv_find_u32(const srt_vector *v, size_t off, uint32_t target);
+
+/* #API: |Find value in vector (SV_I64)|vector; search offset start; target to be located|offset: >=0 found; S_NPOS: not found|O(n)|1;2| */
+size_t sv_find_i64(const srt_vector *v, size_t off, int64_t target);
+
+/* #API: |Find value in vector (SV_U64)|vector; search offset start; target to be located|offset: >=0 found; S_NPOS: not found|O(n)|1;2| */
+size_t sv_find_u64(const srt_vector *v, size_t off, uint64_t target);
+
+/* #API: |Find value in vector (SV_F)|vector; search offset start; target to be located|offset: >=0 found; S_NPOS: not found|O(n)|1;2| */
+size_t sv_find_f(const srt_vector *v, size_t off, float target);
+
+/* #API: |Find value in vector (SV_D)|vector; search offset start; target to be located|offset: >=0 found; S_NPOS: not found|O(n)|1;2| */
+size_t sv_find_d(const srt_vector *v, size_t off, double target);
 
 /*
  * Compare
@@ -237,61 +283,158 @@ int sv_cmp(const srt_vector *v, size_t a_off, size_t b_off);
  * Vector "at": element access to given position
  */
 
-/* #API: |Vector random access (generic data)|vector; location|NULL: not found; != NULL: element reference|O(1)|1;2| */
+/* #API: |Vector random access (SV_GEN)|vector; location|NULL: not found; != NULL: element reference|O(1)|1;2| */
 const void *sv_at(const srt_vector *v, size_t index);
 
-/* #API: |Vector random access (integer)|vector; location|Element value|O(1)|1;2| */
-int64_t sv_at_i(const srt_vector *v, size_t index);
+/* #API: |Vector random access (SV_I8)|vector; location|Element value|O(1)|1;2| */
+int8_t sv_at_i8(const srt_vector *v, size_t index);
 
-/* #API: |Vector random access (unsigned integer)|vector; location|Element value|O(1)|1;2| */
-uint64_t sv_at_u(const srt_vector *v, size_t index);
+/* #API: |Vector random access (SV_U8)|vector; location|Element value|O(1)|1;2| */
+uint8_t sv_at_u8(const srt_vector *v, size_t index);
+
+/* #API: |Vector random access (SV_I16)|vector; location|Element value|O(1)|1;2| */
+int16_t sv_at_i16(const srt_vector *v, size_t index);
+
+/* #API: |Vector random access (SV_U16)|vector; location|Element value|O(1)|1;2| */
+uint16_t sv_at_u16(const srt_vector *v, size_t index);
+
+/* #API: |Vector random access (SV_I32)|vector; location|Element value|O(1)|1;2| */
+int32_t sv_at_i32(const srt_vector *v, size_t index);
+
+/* #API: |Vector random access (SV_U32)|vector; location|Element value|O(1)|1;2| */
+uint32_t sv_at_u32(const srt_vector *v, size_t index);
+
+/* #API: |Vector random access (SV_I64)|vector; location|Element value|O(1)|1;2| */
+int64_t sv_at_i64(const srt_vector *v, size_t index);
+
+/* #API: |Vector random access (SV_U64)|vector; location|Element value|O(1)|1;2| */
+uint64_t sv_at_u64(const srt_vector *v, size_t index);
+
+/* #API: |Vector random access (SV_F)|vector; location|Element value|O(1)|1;2| */
+float sv_at_f(const srt_vector *v, size_t index);
+
+/* #API: |Vector random access (SV_D)|vector; location|Element value|O(1)|1;2| */
+double sv_at_d(const srt_vector *v, size_t index);
 
 /*
  * Vector "set": set element value at given position
  */
 
-/* #API: |Vector random access write (generic data)|vector; location; value|S_TRUE: OK, S_FALSE: not enough memory|O(1)|1;2| */
+/* #API: |Vector random access write (SV_GEN)|vector; location; value|S_TRUE: OK, S_FALSE: not enough memory|O(1)|1;2| */
 srt_bool sv_set(srt_vector **v, size_t index, const void *value);
 
-/* #API: |Vector random access write (integer)|vector; location; value|S_TRUE: OK, S_FALSE: not enough memory|O(1)|1;2| */
-srt_bool sv_set_i(srt_vector **v, size_t index, int64_t value);
+/* #API: |Vector random access write (SV_I8)|vector; location; value|S_TRUE: OK, S_FALSE: not enough memory|O(1)|1;2| */
+srt_bool sv_set_i8(srt_vector **v, size_t index, int8_t value);
 
-/* #API: |Vector random access write (unsigned integer)|vector; location; value|S_TRUE: OK, S_FALSE: not enough memory|O(1)|1;2| */
-srt_bool sv_set_u(srt_vector **v, size_t index, uint64_t value);
+/* #API: |Vector random access write (SV_U8)|vector; location; value|S_TRUE: OK, S_FALSE: not enough memory|O(1)|1;2| */
+srt_bool sv_set_u8(srt_vector **v, size_t index, uint8_t value);
+
+/* #API: |Vector random access write (SV_I16)|vector; location; value|S_TRUE: OK, S_FALSE: not enough memory|O(1)|1;2| */
+srt_bool sv_set_i16(srt_vector **v, size_t index, int16_t value);
+
+/* #API: |Vector random access write (SV_U16)|vector; location; value|S_TRUE: OK, S_FALSE: not enough memory|O(1)|1;2| */
+srt_bool sv_set_u16(srt_vector **v, size_t index, uint16_t value);
+
+/* #API: |Vector random access write (SV_I32)|vector; location; value|S_TRUE: OK, S_FALSE: not enough memory|O(1)|1;2| */
+srt_bool sv_set_i32(srt_vector **v, size_t index, int32_t value);
+
+/* #API: |Vector random access write (SV_U32)|vector; location; value|S_TRUE: OK, S_FALSE: not enough memory|O(1)|1;2| */
+srt_bool sv_set_u32(srt_vector **v, size_t index, uint32_t value);
+
+/* #API: |Vector random access write (SV_I64)|vector; location; value|S_TRUE: OK, S_FALSE: not enough memory|O(1)|1;2| */
+srt_bool sv_set_i64(srt_vector **v, size_t index, int64_t value);
+
+/* #API: |Vector random access write (SV_U64)|vector; location; value|S_TRUE: OK, S_FALSE: not enough memory|O(1)|1;2| */
+srt_bool sv_set_u64(srt_vector **v, size_t index, uint64_t value);
+
+/* #API: |Vector random access write (SV_F)|vector; location; value|S_TRUE: OK, S_FALSE: not enough memory|O(1)|1;2| */
+srt_bool sv_set_f(srt_vector **v, size_t index, float value);
+
+/* #API: |Vector random access write (SV_D)|vector; location; value|S_TRUE: OK, S_FALSE: not enough memory|O(1)|1;2| */
+srt_bool sv_set_d(srt_vector **v, size_t index, double value);
 
 /*
  * Vector "push": add element in the last position
  */
 
-/* #API: |Push/add element (generic data)|vector; data source; number of elements|S_TRUE: added OK; S_FALSE: not enough memory|O(n)|1;2| */
+/* #API: |Push/add element|vector; data source; number of elements|S_TRUE: added OK; S_FALSE: not enough memory|O(n)|1;2| */
 srt_bool sv_push_raw(srt_vector **v, const void *src, size_t n);
 
 /*
-#API: |Push/add multiple elements (generic data)|vector; new element to be added; more elements to be added (optional)|S_TRUE: added OK; S_FALSE: not enough memory|O(1)|1;2|
+#API: |Push/add multiple elements (SV_GEN)|vector; new element to be added; more elements to be added (optional)|S_TRUE: added OK; S_FALSE: not enough memory|O(1)|1;2|
 srt_bool sv_push(srt_vector **v, const void *c1, ...)
 */
 size_t sv_push_aux(srt_vector **v, const void *c1, ...);
 
-/* #API: |Push/add element (integer)|vector; data source|S_TRUE: added OK; S_FALSE: not enough memory|O(1)|1;2| */
-srt_bool sv_push_i(srt_vector **v, int64_t c);
+/* #API: |Push/add element (SV_I8)|vector; data source|S_TRUE: added OK; S_FALSE: not enough memory|O(1)|1;2| */
+srt_bool sv_push_i8(srt_vector **v, int8_t c);
 
-/* #API: |Push/add element (unsigned integer)|vector; data source|S_TRUE: added OK; S_FALSE: not enough memory|O(1)|1;2| */
-srt_bool sv_push_u(srt_vector **v, uint64_t c);
+/* #API: |Push/add element (SV_U8)|vector; data source|S_TRUE: added OK; S_FALSE: not enough memory|O(1)|1;2| */
+srt_bool sv_push_u8(srt_vector **v, uint8_t c);
+
+/* #API: |Push/add element (SV_I16)|vector; data source|S_TRUE: added OK; S_FALSE: not enough memory|O(1)|1;2| */
+srt_bool sv_push_i16(srt_vector **v, int16_t c);
+
+/* #API: |Push/add element (SV_U16)|vector; data source|S_TRUE: added OK; S_FALSE: not enough memory|O(1)|1;2| */
+srt_bool sv_push_u16(srt_vector **v, uint16_t c);
+
+/* #API: |Push/add element (SV_I32)|vector; data source|S_TRUE: added OK; S_FALSE: not enough memory|O(1)|1;2| */
+srt_bool sv_push_i32(srt_vector **v, int32_t c);
+
+/* #API: |Push/add element (SV_U32)|vector; data source|S_TRUE: added OK; S_FALSE: not enough memory|O(1)|1;2| */
+srt_bool sv_push_u32(srt_vector **v, uint32_t c);
+
+/* #API: |Push/add element (SV_I64)|vector; data source|S_TRUE: added OK; S_FALSE: not enough memory|O(1)|1;2| */
+srt_bool sv_push_i64(srt_vector **v, int64_t c);
+
+/* #API: |Push/add element (SV_U64)|vector; data source|S_TRUE: added OK; S_FALSE: not enough memory|O(1)|1;2| */
+srt_bool sv_push_u64(srt_vector **v, uint64_t c);
+
+/* #API: |Push/add element (SV_F)|vector; data source|S_TRUE: added OK; S_FALSE: not enough memory|O(1)|1;2| */
+srt_bool sv_push_f(srt_vector **v, float c);
+
+/* #API: |Push/add element (SV_D)|vector; data source|S_TRUE: added OK; S_FALSE: not enough memory|O(1)|1;2| */
+srt_bool sv_push_d(srt_vector **v, double c);
 
 /*
  * Vector "pop": extract element from last position
  */
 
-/* #API: |Pop/extract element (generic data)|vector|Element reference|O(1)|1;2| */
+/* #API: |Pop/extract element (SV_GEN)|vector|Element reference|O(1)|1;2| */
 void *sv_pop(srt_vector *v);
 
-/* #API: |Pop/extract element (integer)|vector|Integer element|O(1)|1;2| */
-int64_t sv_pop_i(srt_vector *v);
+/* #API: |Pop/extract element (SV_I8)|vector|Integer element|O(1)|1;2| */
+int8_t sv_pop_i8(srt_vector *v);
 
-/* #API: |Pop/extract element (unsigned integer)|vector|Integer element|O(1)|1;2| */
-uint64_t sv_pop_u(srt_vector *v);
+/* #API: |Pop/extract element (SV_U8)|vector|Integer element|O(1)|1;2| */
+uint8_t sv_pop_u8(srt_vector *v);
+
+/* #API: |Pop/extract element (SV_I16)|vector|Integer element|O(1)|1;2| */
+int16_t sv_pop_i16(srt_vector *v);
+
+/* #API: |Pop/extract element (SV_U16)|vector|Integer element|O(1)|1;2| */
+uint16_t sv_pop_u16(srt_vector *v);
+
+/* #API: |Pop/extract element (SV_I32)|vector|Integer element|O(1)|1;2| */
+int32_t sv_pop_i32(srt_vector *v);
+
+/* #API: |Pop/extract element (SV_U32)|vector|Integer element|O(1)|1;2| */
+uint32_t sv_pop_u32(srt_vector *v);
+
+/* #API: |Pop/extract element (SV_I64)|vector|Integer element|O(1)|1;2| */
+int64_t sv_pop_i64(srt_vector *v);
+
+/* #API: |Pop/extract element (SV_U64)|vector|Integer element|O(1)|1;2| */
+uint64_t sv_pop_u64(srt_vector *v);
+
+/* #API: |Pop/extract element (SV_F)|vector|Integer element|O(1)|1;2| */
+float sv_pop_f(srt_vector *v);
+
+/* #API: |Pop/extract element (SV_D)|vector|Integer element|O(1)|1;2| */
+double sv_pop_d(srt_vector *v);
 
 #ifdef __cplusplus
 } /* extern "C" { */
 #endif
 #endif /* SVECTOR_H */
+

--- a/test/bench.cc
+++ b/test/bench.cc
@@ -3,8 +3,8 @@
  *
  * Benchmarks of libsrt vs C++ STL
  *
- * Copyright (c) 2015-2019 F. Aragon. All rights reserved. Released under
- * the BSD 3-Clause License (see the doc/LICENSE file included).
+ * Copyright (c) 2015-2020 F. Aragon. All rights reserved.
+ * Released under the BSD 3-Clause License (see the doc/LICENSE)
  */
 
 #include "../src/libsrt.h"
@@ -15,6 +15,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <sstream>
 
 #if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
 #define S_BENCH_CPP_HM
@@ -36,7 +37,7 @@
 #define BENCH_TIME_US				\
 	((tb.tv_sec - ta.tv_sec) * 1000000 +	\
 	 (tb.tv_nsec - ta.tv_nsec) / 1000)
-#define BENCH_FN(test_fn, count, tid	)			\
+#define BENCH_FN(test_fn, count, tid)			\
 	clock_gettime(CLOCK_REALTIME, &ta);			\
 	t_res = test_fn(count, tid);				\
 	clock_gettime(CLOCK_REALTIME, &tb);			\
@@ -71,750 +72,483 @@
 #define TId2Count(id) ((id & TId_Read10Times) != 0 ? 10 : 0)
 #define TIdTest(id, key) ((id & key) == key)
 
-bool libsrt_map_ii32(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	srt_map *m = sm_alloc(SM_II32, 0);
-	for (size_t i = 0; i < count; i++)
-		sm_insert_ii32(&m, (int32_t)i, (int32_t)i);
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++)
-			(void)sm_at_ii32(m, (int32_t)i);
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++)
-			sm_delete_i(m, (int32_t)i);
-	HOLD_EXEC(tid);
-	sm_free(&m);
-	return true;
-}
+#define LIBSRTM_BENCH(FN, TID, TK, TV, INSF, ATF, DELF)	\
+	bool FN(size_t count, int tid) { \
+		RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) && \
+			  !TIdTest(tid, TId_DeleteOneByOne), false); \
+		srt_map *m = sm_alloc(TID, 0); \
+		for (size_t i = 0; i < count; i++) \
+			INSF(&m, (TK)i, (TV)i); \
+		for (size_t j = 0; j < TId2Count(tid); j++) \
+			for (size_t i = 0; i < count; i++) \
+				(void)ATF(m, (TK)i); \
+		if (TIdTest(tid, TId_DeleteOneByOne)) \
+			for (size_t i = 0; i < count; i++) \
+				DELF(m, (TK)i); \
+		HOLD_EXEC(tid); \
+		sm_free(&m); \
+		return true; \
+	}
 
-bool cxx_map_ii32(size_t count, int tid)
+LIBSRTM_BENCH(libsrt_map_ii32, SM_II32, int32_t, int32_t, sm_insert_ii32,
+	      sm_at_ii32, sm_delete_i)
+LIBSRTM_BENCH(libsrt_map_uu32, SM_UU32, uint32_t, uint32_t, sm_insert_uu32,
+	      sm_at_uu32, sm_delete_i)
+LIBSRTM_BENCH(libsrt_map_ii64, SM_II, int64_t, int64_t, sm_insert_ii,
+	      sm_at_ii, sm_delete_i)
+LIBSRTM_BENCH(libsrt_map_ff, SM_FF, float, float, sm_insert_ff,
+	      sm_at_ff, sm_delete_f)
+LIBSRTM_BENCH(libsrt_map_dd, SM_DD, double, double, sm_insert_dd,
+	      sm_at_dd, sm_delete_d)
+
+template <class TK, class TV>
+bool cxx_map_ii(size_t count, int tid)
 {
 	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
 		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	std::map <int32_t, int32_t> m;
+	std::map <TK, TV> m;
 	for (size_t i = 0; i < count; i++)
-		m[i] = (int32_t)i;
+		m[(TK)i] = (TV)i;
 	for (size_t j = 0; j < TId2Count(tid); j++)
 		for (size_t i = 0; i < count; i++)
 			(void)m[i];
 	if (TIdTest(tid, TId_DeleteOneByOne))
 		for (size_t i = 0; i < count; i++)
-			m.erase((int32_t)i);
+			m.erase((TK)i);
 	HOLD_EXEC(tid);
 	return true;
 }
 
-bool libsrt_map_ii64(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	srt_map *m = sm_alloc(SM_II, 0);
-	for (size_t i = 0; i < count; i++)
-		sm_insert_ii(&m, (int64_t)i, (int64_t)i);
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++)
-			(void)sm_at_ii(m, (int64_t)i);
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++)
-			sm_delete_i(m, (int64_t)i);
-	HOLD_EXEC(tid);
-	sm_free(&m);
-	return true;
-}
+#define cxx_map_ii32 cxx_map_ii<int32_t, int32_t>
+#define cxx_map_uu32 cxx_map_ii<uint32_t, uint32_t>
+#define cxx_map_ii64 cxx_map_ii<int64_t, int64_t>
+#define cxx_map_ff cxx_map_ii<float, float>
+#define cxx_map_dd cxx_map_ii<double, double>
 
-bool cxx_map_ii64(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	std::map <int64_t, int64_t> m;
-	for (size_t i = 0; i < count; i++)
-		m[i] = (int64_t)i;
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++)
-			(void)m[i];
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++)
-			m.erase((int64_t)i);
-	HOLD_EXEC(tid);
-	return true;
-}
-
-bool libsrt_map_s16(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	srt_string *btmp = ss_alloca(512);
-	srt_map *m = sm_alloc(SM_SS, 0);
-	for (size_t i = 0; i < count; i++) {
-		ss_printf(&btmp, 512, "%016i", (int)i);
-		sm_insert_ss(&m, btmp, btmp);
+#define LIBSRTMS_BENCH(FN, FMT)	\
+	bool FN(size_t count, int tid) { \
+		RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) && \
+			  !TIdTest(tid, TId_DeleteOneByOne), false); \
+		srt_string *btmp = ss_alloca(512); \
+		srt_map *m = sm_alloc(SM_SS, 0); \
+		for (size_t i = 0; i < count; i++) { \
+			ss_printf(&btmp, 512, FMT, (int)i); \
+			sm_insert_ss(&m, btmp, btmp); \
+		} \
+		for (size_t j = 0; j < TId2Count(tid); j++) \
+			for (size_t i = 0; i < count; i++) { \
+				ss_printf(&btmp, 512, "%016i", (int)i); \
+				(void)sm_at_ss(m, btmp); \
+			} \
+		if (TIdTest(tid, TId_DeleteOneByOne)) \
+			for (size_t i = 0; i < count; i++) { \
+				ss_printf(&btmp, 512, "%016i", (int)i); \
+				sm_delete_s(m, btmp); \
+			} \
+		HOLD_EXEC(tid); \
+		sm_free(&m); \
+		return true; \
 	}
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++) {
-			ss_printf(&btmp, 512, "%016i", (int)i);
-			(void)sm_at_ss(m, btmp);
-		}
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++) {
-			ss_printf(&btmp, 512, "%016i", (int)i);
-			sm_delete_s(m, btmp);
-		}
-	HOLD_EXEC(tid);
-	sm_free(&m);
-	return true;
-}
 
-bool cxx_map_s16(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	char btmp[512];
-	std::map <std::string, std::string> m;
-	for (size_t i = 0; i < count; i++) {
-		sprintf(btmp, "%016i", (int)i);
-		m[btmp] = btmp;
+LIBSRTMS_BENCH(libsrt_map_s16, "%016i")
+LIBSRTMS_BENCH(libsrt_map_s64, "%064i")
+
+#define CXXMS_BENCH(FN, FMT)	\
+	bool FN(size_t count, int tid) { \
+		RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) && \
+			  !TIdTest(tid, TId_DeleteOneByOne), false); \
+		char btmp[512]; \
+		std::map <std::string, std::string> m; \
+		for (size_t i = 0; i < count; i++) { \
+			sprintf(btmp, FMT, (int)i); \
+			m[btmp] = btmp; \
+		} \
+		for (size_t j = 0; j < TId2Count(tid); j++) \
+			for (size_t i = 0; i < count; i++) { \
+				sprintf(btmp, FMT, (int)i); \
+				(void)m[btmp]; \
+			} \
+		if (TIdTest(tid, TId_DeleteOneByOne)) \
+			for (size_t i = 0; i < count; i++) { \
+				sprintf(btmp, "%016i", (int)i); \
+				m.erase(btmp); \
+			} \
+		HOLD_EXEC(tid); \
+		return true; \
 	}
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++) {
-			sprintf(btmp, "%016i", (int)i);
-			(void)m[btmp];
-		}
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++) {
-			sprintf(btmp, "%016i", (int)i);
-			m.erase(btmp);
-		}
-	HOLD_EXEC(tid);
-	return true;
-}
 
-bool libsrt_map_s64(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	srt_string *btmp = ss_alloca(512);
-	srt_map *m = sm_alloc(SM_SS, 0);
-	for (size_t i = 0; i < count; i++) {
-		ss_printf(&btmp, 512, "%064i", (int)i);
-		sm_insert_ss(&m, btmp, btmp);
+CXXMS_BENCH(cxx_map_s16, "%016i")
+CXXMS_BENCH(cxx_map_s64, "%064i")
+
+#define LIBSRTHM_BENCH(FN, TID, TK, TV, INSF, ATF, DELF)	\
+	bool FN(size_t count, int tid) { \
+		RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) && \
+			  !TIdTest(tid, TId_DeleteOneByOne), false); \
+		srt_hmap *m = shm_alloc(TID, 0); \
+		for (size_t i = 0; i < count; i++) \
+			INSF(&m, (TK)i, (TV)i); \
+		for (size_t j = 0; j < TId2Count(tid); j++) \
+			for (size_t i = 0; i < count; i++) \
+				(void)ATF(m, (TK)i); \
+		if (TIdTest(tid, TId_DeleteOneByOne)) \
+			for (size_t i = 0; i < count; i++) \
+				DELF(m, (TK)i); \
+		HOLD_EXEC(tid); \
+		shm_free(&m); \
+		return true;\
 	}
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++) {
-			ss_printf(&btmp, 512, "%064i", (int)i);
-			(void)sm_at_ss(m, btmp);
-		}
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++) {
-			ss_printf(&btmp, 512, "%064i", (int)i);
-			sm_delete_s(m, btmp);
-		}
-	HOLD_EXEC(tid);
-	sm_free(&m);
-	return true;
-}
 
-bool cxx_map_s64(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	char btmp[512];
-	std::map <std::string, std::string> m;
-	for (size_t i = 0; i < count; i++) {
-		sprintf(btmp, "%064i", (int)i);
-		m[btmp] = btmp;
+LIBSRTHM_BENCH(libsrt_hmap_ii32, SHM_II32, int32_t, int32_t, shm_insert_ii32,
+		shm_at_ii32, shm_delete_i32)
+LIBSRTHM_BENCH(libsrt_hmap_uu32, SHM_UU32, uint32_t, uint32_t, shm_insert_uu32,
+		shm_at_uu32, shm_delete_i32)
+LIBSRTHM_BENCH(libsrt_hmap_ii64, SHM_II, int64_t, int64_t, shm_insert_ii,
+		shm_at_ii, shm_delete_i)
+LIBSRTHM_BENCH(libsrt_hmap_ff, SHM_FF, float, float, shm_insert_ff,
+		shm_at_ff, shm_delete_f)
+LIBSRTHM_BENCH(libsrt_hmap_dd, SHM_DD, double, double, shm_insert_dd,
+		shm_at_dd, shm_delete_d)
+
+#define LIBSRTHMS_BENCH(FN, FMT)	\
+	bool FN(size_t count, int tid) { \
+		RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) && \
+			  !TIdTest(tid, TId_DeleteOneByOne), false); \
+		srt_string *btmp = ss_alloca(512); \
+		srt_hmap *m = shm_alloc(SHM_SS, 0); \
+		for (size_t i = 0; i < count; i++) { \
+			ss_printf(&btmp, 512, FMT, (int)i); \
+			shm_insert_ss(&m, btmp, btmp); \
+		} \
+		for (size_t j = 0; j < TId2Count(tid); j++) \
+			for (size_t i = 0; i < count; i++) { \
+				ss_printf(&btmp, 512, FMT, (int)i); \
+				(void)shm_at_ss(m, btmp); \
+			} \
+		if (TIdTest(tid, TId_DeleteOneByOne)) \
+			for (size_t i = 0; i < count; i++) { \
+				ss_printf(&btmp, 512, FMT, (int)i); \
+				shm_delete_s(m, btmp); \
+			} \
+		HOLD_EXEC(tid); \
+		shm_free(&m); \
+		return true; \
 	}
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++) {
-			sprintf(btmp, "%064i", (int)i);
-			(void)m[btmp];
-		}
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++) {
-			sprintf(btmp, "%064i", (int)i);
-			m.erase(btmp);
-		}
-	HOLD_EXEC(tid);
-	return true;
-}
 
-bool libsrt_hmap_ii32(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	srt_hmap *m = shm_alloc(SHM_II32, 0);
-	for (size_t i = 0; i < count; i++)
-		shm_insert_ii32(&m, (int32_t)i, (int32_t)i);
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++)
-			(void)shm_at_ii32(m, (int32_t)i);
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++)
-			shm_delete_i(m, (int32_t)i);
-	HOLD_EXEC(tid);
-	shm_free(&m);
-	return true;
-}
-
-bool libsrt_hmap_ii64(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	srt_hmap *m = shm_alloc(SHM_II, 0);
-	for (size_t i = 0; i < count; i++)
-		shm_insert_ii(&m, (int64_t)i, (int64_t)i);
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++)
-			(void)shm_at_ii(m, (int64_t)i);
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++)
-			shm_delete_i(m, (int64_t)i);
-	HOLD_EXEC(tid);
-	shm_free(&m);
-	return true;
-}
-
-bool libsrt_hmap_s16(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	srt_string *btmp = ss_alloca(512);
-	srt_hmap *m = shm_alloc(SHM_SS, 0);
-	for (size_t i = 0; i < count; i++) {
-		ss_printf(&btmp, 512, "%016i", (int)i);
-		shm_insert_ss(&m, btmp, btmp);
-	}
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++) {
-			ss_printf(&btmp, 512, "%016i", (int)i);
-			(void)shm_at_ss(m, btmp);
-		}
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++) {
-			ss_printf(&btmp, 512, "%016i", (int)i);
-			shm_delete_s(m, btmp);
-		}
-	HOLD_EXEC(tid);
-	shm_free(&m);
-	return true;
-}
-
-bool libsrt_hmap_s64(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	srt_string *btmp = ss_alloca(512);
-	srt_hmap *m = shm_alloc(SHM_SS, 0);
-	for (size_t i = 0; i < count; i++) {
-		ss_printf(&btmp, 512, "%064i", (int)i);
-		shm_insert_ss(&m, btmp, btmp);
-	}
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++) {
-			ss_printf(&btmp, 512, "%064i", (int)i);
-			(void)shm_at_ss(m, btmp);
-		}
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++) {
-			ss_printf(&btmp, 512, "%064i", (int)i);
-			shm_delete_s(m, btmp);
-		}
-	HOLD_EXEC(tid);
-	shm_free(&m);
-	return true;
-}
+LIBSRTHMS_BENCH(libsrt_hmap_s16, "%016i")
+LIBSRTHMS_BENCH(libsrt_hmap_s64, "%064i")
 
 #ifdef S_BENCH_CPP_HM
 
-bool cxx_umap_ii32(size_t count, int tid)
+template <class TK, class TV>
+bool cxx_umap_ii(size_t count, int tid)
 {
 	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
 		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	std::unordered_map <int32_t, int32_t> m;
+	std::unordered_map <TK, TV> m;
 	for (size_t i = 0; i < count; i++)
-		m[i] = (int32_t)i;
+		m[(TK)i] = (TV)i;
 	for (size_t j = 0; j < TId2Count(tid); j++)
 		for (size_t i = 0; i < count; i++)
 			(void)m.count(i);
 	if (TIdTest(tid, TId_DeleteOneByOne))
 		for (size_t i = 0; i < count; i++)
-			m.erase((int32_t)i);
+			m.erase((TK)i);
 	HOLD_EXEC(tid);
 	return true;
 }
 
-bool cxx_umap_ii64(size_t count, int tid)
+#define cxx_umap_ii32 cxx_umap_ii<int32_t, int32_t>
+#define cxx_umap_uu32 cxx_umap_ii<uint32_t, uint32_t>
+#define cxx_umap_ii64 cxx_umap_ii<int64_t, int64_t>
+#define cxx_umap_ff cxx_umap_ii<float, float>
+#define cxx_umap_dd cxx_umap_ii<double, double>
+
+#define CXXHMS_BENCH(FN, FMT)	\
+	bool FN(size_t count, int tid) { \
+		RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) && \
+			  !TIdTest(tid, TId_DeleteOneByOne), false); \
+		char btmp[512]; \
+		std::unordered_map <std::string, std::string> m; \
+		for (size_t i = 0; i < count; i++) { \
+			sprintf(btmp, "%016i", (int)i); \
+			m[btmp] = btmp; \
+		} \
+		for (size_t j = 0; j < TId2Count(tid); j++) \
+			for (size_t i = 0; i < count; i++) { \
+				sprintf(btmp, "%016i", (int)i); \
+				(void)m.count(btmp); \
+			} \
+		if (TIdTest(tid, TId_DeleteOneByOne)) \
+			for (size_t i = 0; i < count; i++) { \
+				sprintf(btmp, "%016i", (int)i); \
+				m.erase(btmp); \
+			} \
+		HOLD_EXEC(tid); \
+		return true; \
+	}
+
+CXXHMS_BENCH(cxx_umap_s16, "%016i")
+CXXHMS_BENCH(cxx_umap_s64, "%064i")
+
+template <class T>
+bool cxx_uset_i(size_t count, int tid)
 {
 	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
 		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	std::unordered_map <int64_t, int64_t> m;
+	std::unordered_set <T> m;
 	for (size_t i = 0; i < count; i++)
-		m[i] = (int64_t)i;
+		m.insert((T)i);
 	for (size_t j = 0; j < TId2Count(tid); j++)
 		for (size_t i = 0; i < count; i++)
-			(void)m.count(i);
+			(void)m.count((T)i);
 	if (TIdTest(tid, TId_DeleteOneByOne))
 		for (size_t i = 0; i < count; i++)
-			m.erase((int64_t)i);
+			m.erase((T)i);
 	HOLD_EXEC(tid);
 	return true;
 }
 
-bool cxx_umap_s16(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	char btmp[512];
-	std::unordered_map <std::string, std::string> m;
-	for (size_t i = 0; i < count; i++) {
-		sprintf(btmp, "%016i", (int)i);
-		m[btmp] = btmp;
+#define cxx_uset_i32 cxx_uset_i<int32_t>
+#define cxx_uset_u32 cxx_uset_i<uint32_t>
+#define cxx_uset_i64 cxx_uset_i<int64_t>
+#define cxx_uset_f cxx_uset_i<float>
+#define cxx_uset_d cxx_uset_i<double>
+
+#define CXXHSS_BENCH(FN, FMT)	\
+	bool FN(size_t count, int tid) { \
+		RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) && \
+			  !TIdTest(tid, TId_DeleteOneByOne), false); \
+		char btmp[512]; \
+		std::unordered_set <std::string> m; \
+		for (size_t i = 0; i < count; i++) { \
+			sprintf(btmp, FMT, (int)i); \
+			m.insert(btmp); \
+		} \
+		for (size_t j = 0; j < TId2Count(tid); j++) \
+			for (size_t i = 0; i < count; i++) { \
+				sprintf(btmp, FMT, (int)i); \
+				(void)m.count(btmp); \
+			} \
+		if (TIdTest(tid, TId_DeleteOneByOne)) \
+			for (size_t i = 0; i < count; i++) { \
+				sprintf(btmp, FMT, (int)i); \
+				m.erase(btmp); \
+			} \
+		HOLD_EXEC(tid); \
+		return true; \
 	}
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++) {
-			sprintf(btmp, "%016i", (int)i);
-			(void)m.count(btmp);
-		}
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++) {
-			sprintf(btmp, "%016i", (int)i);
-			m.erase(btmp);
-		}
-	HOLD_EXEC(tid);
-	return true;
-}
 
-bool cxx_umap_s64(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	char btmp[512];
-	std::unordered_map <std::string, std::string> m;
-	for (size_t i = 0; i < count; i++) {
-		sprintf(btmp, "%064i", (int)i);
-		m[btmp] = btmp;
+CXXHSS_BENCH(cxx_uset_s16, "%016i")
+CXXHSS_BENCH(cxx_uset_s64, "%064i")
+
+#endif // #ifdef S_BENCH_CPP_HM
+
+#define LIBSRTS_BENCH(FN, TID, TK, INSF, COUNTF, DELF)	\
+	bool FN(size_t count, int tid) { \
+		RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) && \
+			  !TIdTest(tid, TId_DeleteOneByOne), false); \
+		srt_set *m = sms_alloc(TID, 0); \
+		for (size_t i = 0; i < count; i++) \
+			INSF(&m, (TK)i); \
+		for (size_t j = 0; j < TId2Count(tid); j++) \
+			for (size_t i = 0; i < count; i++) \
+				(void)COUNTF(m, (TK)i); \
+		if (TIdTest(tid, TId_DeleteOneByOne)) \
+			for (size_t i = 0; i < count; i++) \
+				DELF(m, (TK)i); \
+		HOLD_EXEC(tid); \
+		sms_free(&m); \
+		return true; \
 	}
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++) {
-			sprintf(btmp, "%064i", (int)i);
-			(void)m.count(btmp);
-		}
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++) {
-			sprintf(btmp, "%064i", (int)i);
-			m.erase(btmp);
-		}
-	HOLD_EXEC(tid);
-	return true;
-}
 
-bool cxx_uset_i32(size_t count, int tid)
+LIBSRTS_BENCH(libsrt_set_i32, SMS_I32, int32_t, sms_insert_i32,
+		sms_count_i32, sms_delete_i)
+LIBSRTS_BENCH(libsrt_set_u32, SMS_U32, uint32_t, sms_insert_u32,
+		sms_count_u32, sms_delete_i)
+LIBSRTS_BENCH(libsrt_set_i64, SMS_I, int64_t, sms_insert_i,
+		sms_count_i, sms_delete_i)
+LIBSRTS_BENCH(libsrt_set_f, SMS_F, float, sms_insert_f,
+		sms_count_f, sms_delete_f)
+LIBSRTS_BENCH(libsrt_set_d, SMS_D, double, sms_insert_d,
+		sms_count_d, sms_delete_d)
+
+template <class T>
+bool cxx_set_i(size_t count, int tid)
 {
 	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
 		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	std::unordered_set <int32_t> m;
+	std::set <T> m;
 	for (size_t i = 0; i < count; i++)
-		m.insert(i);
+		m.insert((T)i);
 	for (size_t j = 0; j < TId2Count(tid); j++)
 		for (size_t i = 0; i < count; i++)
-			(void)m.count(i);
+			(void)m.count((T)i);
 	if (TIdTest(tid, TId_DeleteOneByOne))
 		for (size_t i = 0; i < count; i++)
-			m.erase((int32_t)i);
+			m.erase((T)i);
 	HOLD_EXEC(tid);
 	return true;
 }
 
-bool cxx_uset_i64(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	std::unordered_set <int64_t> m;
-	for (size_t i = 0; i < count; i++)
-		m.insert(i);
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++)
-			(void)m.count(i);
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++)
-			m.erase((int64_t)i);
-	HOLD_EXEC(tid);
-	return true;
-}
+#define cxx_set_i32 cxx_set_i<int32_t>
+#define cxx_set_u32 cxx_set_i<uint32_t>
+#define cxx_set_i64 cxx_set_i<int64_t>
+#define cxx_set_f cxx_set_i<float>
+#define cxx_set_d cxx_set_i<double>
 
-bool cxx_uset_s16(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	char btmp[512];
-	std::unordered_set <std::string> m;
-	for (size_t i = 0; i < count; i++) {
-		sprintf(btmp, "%016i", (int)i);
-		m.insert(btmp);
+#define LIBSRTSS_BENCH(FN, FMT)	\
+	bool FN(size_t count, int tid) { \
+		RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) && \
+			  !TIdTest(tid, TId_DeleteOneByOne), false); \
+		srt_string *btmp = ss_alloca(512); \
+		srt_set *m = sms_alloc(SMS_S, 0); \
+		for (size_t i = 0; i < count; i++) { \
+			ss_printf(&btmp, 512, FMT, (int)i); \
+			sms_insert_s(&m, btmp); \
+		} \
+		for (size_t j = 0; j < TId2Count(tid); j++) \
+			for (size_t i = 0; i < count; i++) { \
+				ss_printf(&btmp, 512, FMT, (int)i); \
+				(void)sms_count_s(m, btmp); \
+			} \
+		if (TIdTest(tid, TId_DeleteOneByOne)) \
+			for (size_t i = 0; i < count; i++) { \
+				ss_printf(&btmp, 512, FMT, (int)i); \
+				sms_delete_s(m, btmp); \
+			} \
+		HOLD_EXEC(tid); \
+		sms_free(&m); \
+		return true; \
 	}
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++) {
-			sprintf(btmp, "%016i", (int)i);
-			(void)m.count(btmp);
-		}
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++) {
-			sprintf(btmp, "%016i", (int)i);
-			m.erase(btmp);
-		}
-	HOLD_EXEC(tid);
-	return true;
-}
 
-bool cxx_uset_s64(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	char btmp[512];
-	std::unordered_set <std::string> m;
-	for (size_t i = 0; i < count; i++) {
-		sprintf(btmp, "%064i", (int)i);
-		m.insert(btmp);
+LIBSRTSS_BENCH(libsrt_set_s16, "%016i")
+LIBSRTSS_BENCH(libsrt_set_s64, "%064i")
+
+#define CXXS_BENCH(FN, FMT)	\
+	bool FN(size_t count, int tid) { \
+		RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) && \
+			  !TIdTest(tid, TId_DeleteOneByOne), false); \
+		char btmp[512]; \
+		std::set <std::string> m; \
+		for (size_t i = 0; i < count; i++) { \
+			sprintf(btmp, FMT, (int)i); \
+			m.insert(btmp); \
+		} \
+		for (size_t j = 0; j < TId2Count(tid); j++) \
+			for (size_t i = 0; i < count; i++) { \
+				sprintf(btmp, FMT, (int)i); \
+				(void)m.count(btmp); \
+			} \
+		if (TIdTest(tid, TId_DeleteOneByOne)) \
+			for (size_t i = 0; i < count; i++) { \
+				sprintf(btmp, FMT, (int)i); \
+				m.erase(btmp); \
+			} \
+		HOLD_EXEC(tid); \
+		return true; \
 	}
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++) {
-			sprintf(btmp, "%064i", (int)i);
-			(void)m.count(btmp);
-		}
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++) {
-			sprintf(btmp, "%064i", (int)i);
-			m.erase(btmp);
-		}
-	HOLD_EXEC(tid);
-	return true;
-}
 
-#endif
+CXXS_BENCH(cxx_set_s16, "%016i")
+CXXS_BENCH(cxx_set_s64, "%064i")
 
-bool libsrt_set_i32(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	srt_set *m = sms_alloc(SMS_I32, 0);
-	for (size_t i = 0; i < count; i++)
-		sms_insert_i32(&m, (int32_t)i);
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++)
-			(void)sms_count_i(m, (int32_t)i);
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++)
-			sms_delete_i(m, (int32_t)i);
-	HOLD_EXEC(tid);
-	sms_free(&m);
-	return true;
-}
-
-bool cxx_set_i32(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	std::set <int32_t> m;
-	for (size_t i = 0; i < count; i++)
-		m.insert((int32_t)i);
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++)
-			(void)m.count(i);
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++)
-			m.erase((int32_t)i);
-	HOLD_EXEC(tid);
-	return true;
-}
-
-bool libsrt_set_i64(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	srt_set *m = sms_alloc(SMS_I, 0);
-	for (size_t i = 0; i < count; i++)
-		sms_insert_i(&m, (int64_t)i);
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++)
-			(void)sms_count_i(m, (int64_t)i);
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++)
-			sms_delete_i(m, (int64_t)i);
-	HOLD_EXEC(tid);
-	sms_free(&m);
-	return true;
-}
-
-bool cxx_set_i64(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	std::set <int64_t> m;
-	for (size_t i = 0; i < count; i++)
-		m.insert((int64_t)i);
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++)
-			(void)m.count(i);
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++)
-			m.erase((int64_t)i);
-	HOLD_EXEC(tid);
-	return true;
-}
-
-bool libsrt_set_s16(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	srt_string *btmp = ss_alloca(512);
-	srt_set *m = sms_alloc(SMS_S, 0);
-	for (size_t i = 0; i < count; i++) {
-		ss_printf(&btmp, 512, "%016i", (int)i);
-		sms_insert_s(&m, btmp);
+#define LIBSRTHS_BENCH(FN, TID, TK, INSF, COUNTF, DELF)	\
+	bool FN(size_t count, int tid) { \
+		RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) && \
+			  !TIdTest(tid, TId_DeleteOneByOne), false); \
+		srt_hset *m = shs_alloc(TID, 0); \
+		for (size_t i = 0; i < count; i++) \
+			INSF(&m, (TK)i); \
+		for (size_t j = 0; j < TId2Count(tid); j++) \
+			for (size_t i = 0; i < count; i++) \
+				(void)COUNTF(m, (TK)i); \
+		if (TIdTest(tid, TId_DeleteOneByOne)) \
+			for (size_t i = 0; i < count; i++) \
+				DELF(m, (TK)i); \
+		HOLD_EXEC(tid); \
+		shs_free(&m); \
+		return true; \
 	}
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++) {
-			ss_printf(&btmp, 512, "%016i", (int)i);
-			(void)sms_count_s(m, btmp);
-		}
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++) {
-			ss_printf(&btmp, 512, "%016i", (int)i);
-			sms_delete_s(m, btmp);
-		}
-	HOLD_EXEC(tid);
-	sms_free(&m);
-	return true;
-}
 
-bool cxx_set_s16(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	char btmp[512];
-	std::set <std::string> m;
-	for (size_t i = 0; i < count; i++) {
-		sprintf(btmp, "%016i", (int)i);
-		m.insert(btmp);
+LIBSRTHS_BENCH(libsrt_hset_i32, SHS_I32, int32_t, shs_insert_i32, shs_count_i32,
+		shs_delete_i32)
+LIBSRTHS_BENCH(libsrt_hset_u32, SHS_U32, uint32_t, shs_insert_u32, shs_count_u32,
+		shs_delete_u32)
+LIBSRTHS_BENCH(libsrt_hset_i64, SHS_I, int64_t, shs_insert_i, shs_count_i,
+		shs_delete_i)
+LIBSRTHS_BENCH(libsrt_hset_f, SHS_F, float, shs_insert_f, shs_count_f,
+		shs_delete_f)
+LIBSRTHS_BENCH(libsrt_hset_d, SHS_D, double, shs_insert_d, shs_count_d,
+		shs_delete_d)
+
+#define LIBSRTHSS_BENCH(FN, FMT)	\
+	bool FN(size_t count, int tid) { \
+		RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) && \
+			  !TIdTest(tid, TId_DeleteOneByOne), false); \
+		srt_string *btmp = ss_alloca(512); \
+		srt_hset *m = shs_alloc(SHS_S, 0); \
+		for (size_t i = 0; i < count; i++) { \
+			ss_printf(&btmp, 512, FMT, (int)i); \
+			shs_insert_s(&m, btmp); \
+		} \
+		for (size_t j = 0; j < TId2Count(tid); j++) \
+			for (size_t i = 0; i < count; i++) { \
+				ss_printf(&btmp, 512, FMT, (int)i); \
+				(void)shs_count_s(m, btmp); \
+			} \
+		if (TIdTest(tid, TId_DeleteOneByOne)) \
+			for (size_t i = 0; i < count; i++) { \
+				ss_printf(&btmp, 512, FMT, (int)i); \
+				shs_delete_s(m, btmp); \
+			} \
+		HOLD_EXEC(tid); \
+		shs_free(&m); \
+		return true; \
 	}
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++) {
-			sprintf(btmp, "%016i", (int)i);
-			(void)m.count(btmp);
-		}
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++) {
-			sprintf(btmp, "%016i", (int)i);
-			m.erase(btmp);
-		}
-	HOLD_EXEC(tid);
-	return true;
+
+LIBSRTHSS_BENCH(libsrt_hset_s16, "%016i")
+LIBSRTHSS_BENCH(libsrt_hset_s64, "%064i")
+
+#define LIBSRTV_BENCH(FN, t, PUSH, POP, AT)	\
+	bool FN(size_t count, int tid) {	\
+	RETURN_IF(!TIdTest(tid, TId_Base) &&			\
+		  !TIdTest(tid, TId_Read10Times) &&		\
+		  !TIdTest(tid, TId_DeleteOneByOne) &&		\
+		  !TIdTest(tid, TId_Sort10Times) &&		\
+		  !TIdTest(tid, TId_Sort10000Times), false);	\
+	srt_vector *v = sv_alloc_t(t, 0);			\
+	if (TIdTest(tid, TId_ReverseSort))			\
+		for (size_t i = 0; i < count; i++)		\
+			PUSH(&v, (int32_t)count - 1 - (int32_t)i);	\
+	else								\
+		for (size_t i = 0; i < count; i++)			\
+			PUSH(&v, (int32_t)i);				\
+	for (size_t j = 0; j < TId2Count(tid); j++)			\
+		for (size_t i = 0; i < count; i++)			\
+			(void)AT(v, i);					\
+	if (TIdTest(tid, TId_DeleteOneByOne))				\
+		for (size_t i = 0; i < count; i++)			\
+			(void)POP(v);					\
+	if (TIdTest(tid, TId_Sort10Times) ||				\
+	    TIdTest(tid, TId_Sort10000Times)) {				\
+		size_t cnt = TIdTest(tid, TId_Sort10Times) ? 10 : 10000;\
+		for (size_t i = 0; i < cnt; i++)			\
+			sv_sort(v);					\
+	}								\
+	HOLD_EXEC(tid);							\
+	sv_free(&v);							\
+	return true;							\
 }
 
-bool libsrt_set_s64(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	srt_string *btmp = ss_alloca(512);
-	srt_set *m = sms_alloc(SMS_S, 0);
-	for (size_t i = 0; i < count; i++) {
-		ss_printf(&btmp, 512, "%064i", (int)i);
-		sms_insert_s(&m, btmp);
-	}
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++) {
-			ss_printf(&btmp, 512, "%064i", (int)i);
-			(void)sms_count_s(m, btmp);
-		}
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++) {
-			ss_printf(&btmp, 512, "%064i", (int)i);
-			sms_delete_s(m, btmp);
-		}
-	HOLD_EXEC(tid);
-	sms_free(&m);
-	return true;
-}
-
-bool cxx_set_s64(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	char btmp[512];
-	std::set <std::string> m;
-	for (size_t i = 0; i < count; i++) {
-		sprintf(btmp, "%064i", (int)i);
-		m.insert(btmp);
-	}
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++) {
-			sprintf(btmp, "%064i", (int)i);
-			(void)m.count(btmp);
-		}
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++) {
-			sprintf(btmp, "%064i", (int)i);
-			m.erase(btmp);
-		}
-	HOLD_EXEC(tid);
-	return true;
-}
-
-bool libsrt_hset_i32(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	srt_hset *m = shs_alloc(SHS_I32, 0);
-	for (size_t i = 0; i < count; i++)
-		shs_insert_i32(&m, (int32_t)i);
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++)
-			(void)shs_count_i(m, (int32_t)i);
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++)
-			shs_delete_i(m, (int32_t)i);
-	HOLD_EXEC(tid);
-	shs_free(&m);
-	return true;
-}
-
-bool libsrt_hset_i64(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	srt_hset *m = shs_alloc(SHS_I, 0);
-	for (size_t i = 0; i < count; i++)
-		shs_insert_i(&m, (int64_t)i);
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++)
-			(void)shs_count_i(m, (int64_t)i);
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++)
-			shs_delete_i(m, (int64_t)i);
-	HOLD_EXEC(tid);
-	shs_free(&m);
-	return true;
-}
-
-bool libsrt_hset_s16(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	srt_string *btmp = ss_alloca(512);
-	srt_hset *m = shs_alloc(SHS_S, 0);
-	for (size_t i = 0; i < count; i++) {
-		ss_printf(&btmp, 512, "%016i", (int)i);
-		shs_insert_s(&m, btmp);
-	}
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++) {
-			ss_printf(&btmp, 512, "%016i", (int)i);
-			(void)shs_count_s(m, btmp);
-		}
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++) {
-			ss_printf(&btmp, 512, "%016i", (int)i);
-			shs_delete_s(m, btmp);
-		}
-	HOLD_EXEC(tid);
-	shs_free(&m);
-	return true;
-}
-
-bool libsrt_hset_s64(size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne), false);
-	srt_string *btmp = ss_alloca(512);
-	srt_hset *m = shs_alloc(SHS_S, 0);
-	for (size_t i = 0; i < count; i++) {
-		ss_printf(&btmp, 512, "%064i", (int)i);
-		shs_insert_s(&m, btmp);
-	}
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++) {
-			ss_printf(&btmp, 512, "%064i", (int)i);
-			(void)shs_count_s(m, btmp);
-		}
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++) {
-			ss_printf(&btmp, 512, "%064i", (int)i);
-			shs_delete_s(m, btmp);
-		}
-	HOLD_EXEC(tid);
-	shs_free(&m);
-	return true;
-}
-
-bool libsrt_vector_i(enum eSV_Type t, size_t count, int tid)
-{
-	RETURN_IF(!TIdTest(tid, TId_Base) && !TIdTest(tid, TId_Read10Times) &&
-		  !TIdTest(tid, TId_DeleteOneByOne) &&
-		  !TIdTest(tid, TId_Sort10Times) &&
-		  !TIdTest(tid, TId_Sort10000Times), false);
-	srt_vector *v = sv_alloc_t(t, 0);
-	if (TIdTest(tid, TId_ReverseSort))
-		for (size_t i = 0; i < count; i++)
-			sv_push_i(&v, (int32_t)count - 1 - (int32_t)i);
-	else
-		for (size_t i = 0; i < count; i++)
-			sv_push_i(&v, (int32_t)i);
-	for (size_t j = 0; j < TId2Count(tid); j++)
-		for (size_t i = 0; i < count; i++)
-			(void)sv_at_i(v, i);
-	if (TIdTest(tid, TId_DeleteOneByOne))
-		for (size_t i = 0; i < count; i++)
-			(void)sv_pop_i(v);
-	if (TIdTest(tid, TId_Sort10Times) || TIdTest(tid, TId_Sort10000Times)) {
-		size_t cnt = TIdTest(tid, TId_Sort10Times) ? 10 : 10000;
-		for (size_t i = 0; i < cnt; i++)
-			sv_sort(v);
-	}
-	HOLD_EXEC(tid);
-	sv_free(&v);
-	return true;
-}
-
-bool libsrt_vector_i8(size_t count, int tid)
-{
-	return libsrt_vector_i(SV_I8, count, tid);
-}
-
-bool libsrt_vector_u8(size_t count, int tid)
-{
-	return libsrt_vector_i(SV_U8, count, tid);
-}
-
-bool libsrt_vector_i16(size_t count, int tid)
-{
-	return libsrt_vector_i(SV_I16, count, tid);
-}
-
-bool libsrt_vector_u16(size_t count, int tid)
-{
-	return libsrt_vector_i(SV_U16, count, tid);
-}
-
-bool libsrt_vector_i32(size_t count, int tid)
-{
-	return libsrt_vector_i(SV_I32, count, tid);
-}
-
-bool libsrt_vector_u32(size_t count, int tid)
-{
-	return libsrt_vector_i(SV_U32, count, tid);
-}
-
-bool libsrt_vector_i64(size_t count, int tid)
-{
-	return libsrt_vector_i(SV_I64, count, tid);
-}
-
-bool libsrt_vector_u64(size_t count, int tid)
-{
-	return libsrt_vector_i(SV_U64, count, tid);
-}
+LIBSRTV_BENCH(libsrt_vector_i8, SV_I8, sv_push_i8, sv_pop_i8, sv_at_i8)
+LIBSRTV_BENCH(libsrt_vector_u8, SV_U8, sv_push_u8, sv_pop_u8, sv_at_u8)
+LIBSRTV_BENCH(libsrt_vector_i16, SV_I16, sv_push_i16, sv_pop_i16, sv_at_i16)
+LIBSRTV_BENCH(libsrt_vector_u16, SV_U16, sv_push_u16, sv_pop_u16, sv_at_u16)
+LIBSRTV_BENCH(libsrt_vector_i32, SV_I32, sv_push_i32, sv_pop_i32, sv_at_i32)
+LIBSRTV_BENCH(libsrt_vector_u32, SV_U32, sv_push_u32, sv_pop_u32, sv_at_u32)
+LIBSRTV_BENCH(libsrt_vector_i64, SV_I64, sv_push_i64, sv_pop_i64, sv_at_i64)
+LIBSRTV_BENCH(libsrt_vector_u64, SV_U64, sv_push_u64, sv_pop_u64, sv_at_u64)
+LIBSRTV_BENCH(libsrt_vector_f, SV_F, sv_push_f, sv_pop_f, sv_at_f)
+LIBSRTV_BENCH(libsrt_vector_d, SV_D, sv_push_d, sv_pop_d, sv_at_d)
 
 template <typename T>
 bool cxx_vector(size_t count, int tid)
@@ -845,45 +579,16 @@ bool cxx_vector(size_t count, int tid)
 	return true;
 }
 
-bool cxx_vector_i8(size_t count, int tid)
-{
-	return cxx_vector<int8_t>(count, tid);
-}
-
-bool cxx_vector_u8(size_t count, int tid)
-{
-	return cxx_vector<uint8_t>(count, tid);
-}
-
-bool cxx_vector_i16(size_t count, int tid)
-{
-	return cxx_vector<int16_t>(count, tid);
-}
-
-bool cxx_vector_u16(size_t count, int tid)
-{
-	return cxx_vector<uint16_t>(count, tid);
-}
-
-bool cxx_vector_i32(size_t count, int tid)
-{
-	return cxx_vector<int32_t>(count, tid);
-}
-
-bool cxx_vector_u32(size_t count, int tid)
-{
-	return cxx_vector<uint32_t>(count, tid);
-}
-
-bool cxx_vector_i64(size_t count, int tid)
-{
-	return cxx_vector<int64_t>(count, tid);
-}
-
-bool cxx_vector_u64(size_t count, int tid)
-{
-	return cxx_vector<uint64_t>(count, tid);
-}
+#define cxx_vector_i8 cxx_vector<int8_t>
+#define cxx_vector_u8 cxx_vector<uint8_t>
+#define cxx_vector_i16 cxx_vector<int16_t>
+#define cxx_vector_u16 cxx_vector<uint16_t>
+#define cxx_vector_i32 cxx_vector<int32_t>
+#define cxx_vector_u32 cxx_vector<uint32_t>
+#define cxx_vector_i64 cxx_vector<int64_t>
+#define cxx_vector_u64 cxx_vector<uint64_t>
+#define cxx_vector_f cxx_vector<float>
+#define cxx_vector_d cxx_vector<double>
 
 struct StrGenTest
 {
@@ -1359,7 +1064,6 @@ bool cxx_string_cat(size_t count, int tid)
 	return true;
 }
 
-#if 0 /* it is too low (2 orders of magnitude slower tan plain std::string) */
 bool cxx_stringstream_cat(size_t count, int tid)
 {
 	RETURN_IF(!TIdTest(tid, TId_Base), false);
@@ -1368,12 +1072,13 @@ bool cxx_stringstream_cat(size_t count, int tid)
 	for (size_t i = 0; i < cat_test_ops; i++)
 		s[i] = cat_test[i];
 	for (size_t i = 0; i < count; i++) {
+		ss.clear();
+		ss.str("");
 		ss << s[0] << s[1] << s[2] << s[3] << s[4] << s[5] << s[6];
 		out = ss.str();
 	}
 	return true;
 }
-#endif
 
 bool libsrt_bitset(size_t count, int tid)
 {
@@ -1490,11 +1195,29 @@ int main(int argc, char *argv[])
 #ifdef S_BENCH_CPP_HM
 		BENCH_FN(cxx_umap_ii32, count[i], tid[i]);
 #endif
+		BENCH_FN(libsrt_map_uu32, count[i], tid[i]);
+		BENCH_FN(cxx_map_uu32, count[i], tid[i]);
+		BENCH_FN(libsrt_hmap_uu32, count[i], tid[i]);
+#ifdef S_BENCH_CPP_HM
+		BENCH_FN(cxx_umap_uu32, count[i], tid[i]);
+#endif
 		BENCH_FN(libsrt_map_ii64, count[i], tid[i]);
 		BENCH_FN(cxx_map_ii64, count[i], tid[i]);
 		BENCH_FN(libsrt_hmap_ii64, count[i], tid[i]);
 #ifdef S_BENCH_CPP_HM
 		BENCH_FN(cxx_umap_ii64, count[i], tid[i]);
+#endif
+		BENCH_FN(libsrt_map_ff, count[i], tid[i]);
+		BENCH_FN(cxx_map_ff, count[i], tid[i]);
+		BENCH_FN(libsrt_hmap_ff, count[i], tid[i]);
+#ifdef S_BENCH_CPP_HM
+		BENCH_FN(cxx_umap_ff, count[i], tid[i]);
+#endif
+		BENCH_FN(libsrt_map_dd, count[i], tid[i]);
+		BENCH_FN(cxx_map_dd, count[i], tid[i]);
+		BENCH_FN(libsrt_hmap_dd, count[i], tid[i]);
+#ifdef S_BENCH_CPP_HM
+		BENCH_FN(cxx_umap_dd, count[i], tid[i]);
 #endif
 		BENCH_FN(libsrt_map_s16, count[i], tid[i]);
 		BENCH_FN(cxx_map_s16, count[i], tid[i]);
@@ -1514,11 +1237,29 @@ int main(int argc, char *argv[])
 #ifdef S_BENCH_CPP_HM
 		BENCH_FN(cxx_uset_i32, count[i], tid[i]);
 #endif
+		BENCH_FN(libsrt_set_u32, count[i], tid[i]);
+		BENCH_FN(cxx_set_u32, count[i], tid[i]);
+		BENCH_FN(libsrt_hset_u32, count[i], tid[i]);
+#ifdef S_BENCH_CPP_HM
+		BENCH_FN(cxx_uset_u32, count[i], tid[i]);
+#endif
 		BENCH_FN(libsrt_set_i64, count[i], tid[i]);
 		BENCH_FN(cxx_set_i64, count[i], tid[i]);
 		BENCH_FN(libsrt_hset_i64, count[i], tid[i]);
 #ifdef S_BENCH_CPP_HM
 		BENCH_FN(cxx_uset_i64, count[i], tid[i]);
+#endif
+		BENCH_FN(libsrt_set_f, count[i], tid[i]);
+		BENCH_FN(cxx_set_f, count[i], tid[i]);
+		BENCH_FN(libsrt_hset_f, count[i], tid[i]);
+#ifdef S_BENCH_CPP_HM
+		BENCH_FN(cxx_uset_f, count[i], tid[i]);
+#endif
+		BENCH_FN(libsrt_set_d, count[i], tid[i]);
+		BENCH_FN(cxx_set_d, count[i], tid[i]);
+		BENCH_FN(libsrt_hset_d, count[i], tid[i]);
+#ifdef S_BENCH_CPP_HM
+		BENCH_FN(cxx_uset_d, count[i], tid[i]);
 #endif
 		BENCH_FN(libsrt_set_s16, count[i], tid[i]);
 		BENCH_FN(cxx_set_s16, count[i], tid[i]);
@@ -1548,6 +1289,10 @@ int main(int argc, char *argv[])
 		BENCH_FN(cxx_vector_i64, count[i], tid[i]);
 		BENCH_FN(libsrt_vector_u64, count[i], tid[i]);
 		BENCH_FN(cxx_vector_u64, count[i], tid[i]);
+		BENCH_FN(libsrt_vector_f, count[i], tid[i]);
+		BENCH_FN(cxx_vector_f, count[i], tid[i]);
+		BENCH_FN(libsrt_vector_d, count[i], tid[i]);
+		BENCH_FN(cxx_vector_d, count[i], tid[i]);
 		BENCH_FN(libsrt_vector_gen, count[i], tid[i]);
 		BENCH_FN(cxx_vector_gen, count[i], tid[i]);
 		BENCH_FN(libsrt_string_search_easymatch_long_1a, count[i],
@@ -1607,6 +1352,7 @@ int main(int argc, char *argv[])
 		BENCH_FN(libsrt_string_cat, count[i] / 10, tid[i]);
 		BENCH_FN(c_string_cat, count[i] / 10, tid[i]);
 		BENCH_FN(cxx_string_cat, count[i] / 10, tid[i]);
+		BENCH_FN(cxx_stringstream_cat, count[i] / 10, tid[i]);
 	}
 	return 0;
 }


### PR DESCRIPTION
New types for vectors:

	SV_F: float (single-precision floating point)
	SV_D: double (double-precision floating point)

New types for maps:

	SM_FF: float key, float value
	SM_DD: float key, float value
	SM_DS: double key, string value
	SM_DP: double key, pointer value
	SM_SD: string key, double value

New types for sets:

	SMS_F: float key
	SMS_D: double key

New types for hash maps:

	SHM_FF: float key, float value
	SHM_DD: double key, double value
	SHM_DS: double key, string value
	SHM_DP: double key, pointer value
	SHM_SD: string key, double value

New types for hash sets:

	SHS_F: float key
	SHS_D: double key