### PR TITLE
Use system compiler flags if set

### DIFF
--- a/Makefile.posix
+++ b/Makefile.posix
@@ -104,10 +104,10 @@ ifndef OCTEON
 	endif
 endif
 
-CFLAGS =
-CXXFLAGS =
-LDLIBS =
-LDFLAGS =
+CFLAGS ?=
+CXXFLAGS ?=
+LDLIBS ?=
+LDFLAGS ?=
 COMMON_FLAGS = -pipe
 CPP_MODE = 0
 GNUC = 0


### PR DESCRIPTION
When building an RPM package system compiler flags are set. They include -g/-gdwarf-4 to enable debuginfo which is futher stripped automatically and put into a separate package into a separate repository (https://mirror.rosalinux.ru/rosa/rosa2021.1/repository/x86_64/debug_contrib/release/)

Append system flags instead of ignoring them.